### PR TITLE
Disallow `-- cmd` on session resume

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "realm-cli"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "realm-cli"
-version = "0.0.25"
+version = "0.0.26"
 edition = "2021"
 description = "Sandboxed Docker environments for git repos"
 license = "MIT"

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
         realm = pkgs.rustPlatform.buildRustPackage {
           pname = "realm";
-          version = "0.0.25";
+          version = "0.0.26";
 
           src = ./.;
 


### PR DESCRIPTION
## Summary
- Reject `-- cmd` early in `cmd_resume()` with a clear error message, preventing confusing behavior where commands were either silently ignored (running container) or caused state destruction (stopped container)
- Simplify resume logic since `cmd` is guaranteed empty after the check — remove `final_cmd` ternary, use `sess.command` directly
- Add test `test_resume_rejects_command`

## Test plan
- [x] `cargo test` — all 83 tests pass
- [ ] Manual: `realm foo -- bash` on existing session → error message
- [ ] Manual: `realm foo` on existing session → resumes normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)