### PR TITLE
Refactor CLI to use proper clap subcommands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "realm-cli"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "realm-cli"
-version = "0.0.26"
+version = "0.0.27"
 edition = "2021"
 description = "Sandboxed Docker environments for git repos"
 license = "MIT"

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
         realm = pkgs.rustPlatform.buildRustPackage {
           pname = "realm";
-          version = "0.0.26";
+          version = "0.0.27";
 
           src = ./.;
 


### PR DESCRIPTION
## Summary
- Replace ad-hoc positional arg parsing with proper clap `#[derive(Subcommand)]` for `path` and `upgrade` commands
- Session-related args are now grouped in a `SessionArgs` struct using `#[command(flatten)]`
- Clap now enforces argument validation at parse time (e.g. `path` requires a name, rejects flags), removing manual runtime checks
- Bump version to v0.0.27

## Test plan
- [ ] `realm` — opens interactive TUI
- [ ] `realm my-session` — creates/resumes session
- [ ] `realm path my-session` — prints workspace path
- [ ] `realm upgrade` — runs self-update
- [ ] `realm path` (no name) — clap error
- [ ] `realm path foo -d` — clap error
- [ ] `cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)