### PR TITLE
Document REALM_DEFAULT_CMD in help output and READMEs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "realm-cli"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "realm-cli"
-version = "0.0.29"
+version = "0.0.30"
 edition = "2021"
 description = "Sandboxed Docker environments for git repos"
 license = "MIT"

--- a/README.ja.md
+++ b/README.ja.md
@@ -87,6 +87,7 @@ docker build -t mydev .
 ```bash
 export REALM_DEFAULT_IMAGE=mydev              # カスタムイメージ
 export REALM_DOCKER_ARGS="--network host"     # 常に使いたいDockerフラグ
+export REALM_DEFAULT_CMD="bash"               # 新規セッションのデフォルトコマンド
 ```
 
 **4. 完了 — あとは realm を使うだけ**
@@ -176,6 +177,7 @@ CLIフラグを完全に省略するためのデフォルト設定です。`.zsh
 |----------|-------------|
 | `REALM_DEFAULT_IMAGE` | 新規セッションのデフォルトDockerイメージ（デフォルト: `alpine:latest`） |
 | `REALM_DOCKER_ARGS` | デフォルトの追加Dockerフラグ。`--docker-args` が指定されていない場合に使用 |
+| `REALM_DEFAULT_CMD` | 新規セッションのデフォルトコマンド。`-- cmd` が指定されていない場合に使用 |
 
 ```bash
 # 全セッションにデフォルトのDockerフラグを設定

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Add these to your `.zshrc` or `.bashrc`:
 ```bash
 export REALM_DEFAULT_IMAGE=mydev              # your custom image
 export REALM_DOCKER_ARGS="--network host"     # any extra Docker flags you always want
+export REALM_DEFAULT_CMD="bash"               # default command for new sessions
 ```
 
 **4. Done — just use realm**
@@ -176,6 +177,7 @@ These let you configure defaults so you can skip CLI flags entirely. Set them in
 |----------|-------------|
 | `REALM_DEFAULT_IMAGE` | Default Docker image for new sessions (default: `alpine:latest`) |
 | `REALM_DOCKER_ARGS` | Default extra Docker flags, used when `--docker-args` is not provided |
+| `REALM_DEFAULT_CMD` | Default command for new sessions, used when no `-- cmd` is provided |
 
 ```bash
 # Set default Docker flags for all sessions

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
         realm = pkgs.rustPlatform.buildRustPackage {
           pname = "realm";
-          version = "0.0.29";
+          version = "0.0.30";
 
           src = ./.;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,7 @@ struct SessionArgs {
     #[arg(long = "no-ssh")]
     no_ssh: bool,
 
-    /// Command to run in container
+    /// Command to run in container (default: $REALM_DEFAULT_CMD if set)
     #[arg(last = true)]
     cmd: Vec<String>,
 }


### PR DESCRIPTION
## Summary
- Add `REALM_DEFAULT_CMD` to the CLI help text for the `cmd` argument
- Add `REALM_DEFAULT_CMD` to the environment variables table in README (EN/JA)
- Add `REALM_DEFAULT_CMD` to the Custom Image Setup examples in README (EN/JA)

v0.0.30

🤖 Generated with [Claude Code](https://claude.com/claude-code)