### PR TITLE
Fix TUI explicitly empty command falling back to REALM_DEFAULT_CMD

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "realm-cli"
-version = "0.0.31"
+version = "0.0.32"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "realm-cli"
-version = "0.0.31"
+version = "0.0.32"
 edition = "2021"
 description = "Sandboxed Docker environments for git repos"
 license = "MIT"

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
         realm = pkgs.rustPlatform.buildRustPackage {
           pname = "realm";
-          version = "0.0.31";
+          version = "0.0.32";
 
           src = ./.;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,7 +153,7 @@ fn cmd_create(
     name: &str,
     image: Option<String>,
     docker_args: &str,
-    cmd: Vec<String>,
+    cmd: Option<Vec<String>>,
     ssh: bool,
     detach: bool,
 ) -> Result<i32> {
@@ -220,6 +220,7 @@ fn cmd_create_or_resume(
     }
 
     // Session doesn't exist - create it
+    let cmd = if cmd.is_empty() { None } else { Some(cmd) };
     cmd_create(name, image, &docker_args, cmd, ssh, detach)
 }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -15,7 +15,7 @@ pub enum TuiAction {
     New {
         name: String,
         image: Option<String>,
-        command: Vec<String>,
+        command: Option<Vec<String>>,
     },
     Quit,
 }
@@ -391,10 +391,10 @@ where
                     KeyCode::Enter => {
                         let cmd_text = input.text.trim().to_string();
                         let command = if cmd_text.is_empty() {
-                            vec![]
+                            Some(vec![])
                         } else {
                             match shell_words::split(&cmd_text) {
-                                Ok(args) => args,
+                                Ok(args) => Some(args),
                                 Err(e) => {
                                     footer_msg = format!("Invalid command: {e}");
                                     mode = Mode::Normal;


### PR DESCRIPTION
## Summary
- Change `RealmConfigInput.command` from `Vec<String>` to `Option<Vec<String>>` to distinguish "unspecified" (`None`) from "explicitly empty" (`Some(vec![])`)
- TUI now wraps command input in `Some(...)`, so clearing the pre-filled `REALM_DEFAULT_CMD` and submitting empty correctly skips the fallback
- CLI path converts empty `Vec<String>` to `None` before calling `cmd_create`, preserving existing behavior

## Test plan
- [x] `cargo build` compiles cleanly
- [x] `cargo test` — all 97 tests pass including new `test_resolve_explicit_empty_command_skips_default`
- [ ] Manual: set `REALM_DEFAULT_CMD=bash`, open TUI, create new realm, clear command field, submit → container starts with no command

🤖 Generated with [Claude Code](https://claude.com/claude-code)