### PR TITLE
Fix terminal cursor recovery and screen refresh on container resume

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "realm-cli"
-version = "0.0.32"
+version = "0.0.33"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "realm-cli"
-version = "0.0.32"
+version = "0.0.33"
 edition = "2021"
 description = "Sandboxed Docker environments for git repos"
 license = "MIT"

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
         realm = pkgs.rustPlatform.buildRustPackage {
           pname = "realm";
-          version = "0.0.32";
+          version = "0.0.33";
 
           src = ./.;
 


### PR DESCRIPTION
## Summary
- Add `restore_terminal()` helper that writes show-cursor (`\x1b[?25h`) and reset-attributes (`\x1b[0m`) escape sequences after interactive Docker sessions
- Call `restore_terminal()` after `run_container()` (non-detached) and `attach_container()` to fix invisible cursor when container apps hide it
- Split `start_container()` into background start + attach to eliminate PTY size race condition that caused broken display on resume

## Test plan
- [ ] `realm <session>` → run `python3 -c "print('\x1b[?25l')"` inside → exit → confirm cursor is visible
- [ ] Create session → exit → `realm <session>` to resume → confirm display renders correctly without needing to resize
- [ ] `cargo build` and `cargo test` pass with no regressions

v0.0.33

🤖 Generated with [Claude Code](https://claude.com/claude-code)