### PR TITLE
Walk up directory tree to find git root for realm creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "realm-cli"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "realm-cli"
-version = "0.0.33"
+version = "0.0.34"
 edition = "2021"
 description = "Sandboxed Docker environments for git repos"
 license = "MIT"

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
         realm = pkgs.rustPlatform.buildRustPackage {
           pname = "realm";
-          version = "0.0.33";
+          version = "0.0.34";
 
           src = ./.;
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -4,6 +4,20 @@ pub fn is_repo(dir: &Path) -> bool {
     dir.join(".git").exists()
 }
 
+/// Walk up from `dir` to find the nearest ancestor containing `.git`.
+pub fn find_root(dir: &Path) -> Option<&Path> {
+    let mut current = dir;
+    loop {
+        if is_repo(current) {
+            return Some(current);
+        }
+        match current.parent() {
+            Some(parent) => current = parent,
+            None => return None,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -37,5 +51,39 @@ mod tests {
     #[test]
     fn test_is_repo_nonexistent() {
         assert!(!is_repo(Path::new("/nonexistent/path/12345")));
+    }
+
+    #[test]
+    fn test_find_root_at_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::process::Command::new("git")
+            .args(["init", tmp.path().to_str().unwrap()])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .unwrap();
+        assert_eq!(find_root(tmp.path()), Some(tmp.path()));
+    }
+
+    #[test]
+    fn test_find_root_from_subdirectory() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::process::Command::new("git")
+            .args(["init", tmp.path().to_str().unwrap()])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .unwrap();
+        let sub = tmp.path().join("a").join("b").join("c");
+        std::fs::create_dir_all(&sub).unwrap();
+        assert_eq!(find_root(&sub), Some(tmp.path()));
+    }
+
+    #[test]
+    fn test_find_root_no_repo() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sub = tmp.path().join("no_repo");
+        std::fs::create_dir_all(&sub).unwrap();
+        assert_eq!(find_root(&sub), None);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -159,14 +159,13 @@ fn cmd_create(
 ) -> Result<i32> {
     session::validate_name(name)?;
 
-    let project_dir = fs::canonicalize(".")
-        .map_err(|_| anyhow::anyhow!("Cannot resolve current directory."))?
+    let cwd =
+        fs::canonicalize(".").map_err(|_| anyhow::anyhow!("Cannot resolve current directory."))?;
+
+    let project_dir = git::find_root(&cwd)
+        .ok_or_else(|| anyhow::anyhow!("'{}' is not inside a git repository.", cwd.display()))?
         .to_string_lossy()
         .to_string();
-
-    if !git::is_repo(Path::new(&project_dir)) {
-        bail!("'{}' is not a git repository.", project_dir);
-    }
 
     docker::check()?;
 


### PR DESCRIPTION
## Summary
- `realm create` now works from any subdirectory within a git repo, not just the repo root
- Added `git::find_root()` that walks up the directory tree to find the nearest `.git`
- Replaced the flat `is_repo()` check in `cmd_create` with the new traversal

## Test plan
- [x] Unit tests for `find_root` at root, from subdirectory, and with no repo
- [ ] Manual: run `realm <name>` from a subdirectory of a git repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)