### PR TITLE
Add CMD column to TUI session list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "box-cli"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "box-cli"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 description = "Sandboxed Docker environments for git repos"
 license = "MIT"

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
         box = pkgs.rustPlatform.buildRustPackage {
           pname = "box";
-          version = "0.0.1";
+          version = "0.0.2";
 
           src = ./.;
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -35,6 +35,7 @@ pub struct SessionSummary {
     pub name: String,
     pub project_dir: String,
     pub image: String,
+    pub command: String,
     pub created_at: String,
     pub running: bool,
 }
@@ -184,11 +185,20 @@ pub fn list() -> Result<Vec<SessionSummary>> {
         let created_at = fs::read_to_string(session_path.join("created_at"))
             .map(|s| s.trim().to_string())
             .unwrap_or_default();
+        let command = fs::read_to_string(session_path.join("command"))
+            .map(|s| {
+                s.split('\0')
+                    .filter(|l| !l.is_empty())
+                    .collect::<Vec<_>>()
+                    .join(" ")
+            })
+            .unwrap_or_default();
 
         sessions.push(SessionSummary {
             name,
             project_dir,
             image,
+            command,
             created_at,
             running: false,
         });

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -185,14 +185,14 @@ where
 
             // Table
             {
-                let header = Row::new(["NAME", "STATUS", "PROJECT", "IMAGE", "CREATED"])
+                let header = Row::new(["NAME", "STATUS", "PROJECT", "IMAGE", "CMD", "CREATED"])
                     .style(Style::default().dim());
 
                 let total_rows = 1 + items.len(); // "new session" + actual sessions
                 let mut rows: Vec<Row> = Vec::with_capacity(total_rows);
 
                 // First row: "+ new session"
-                rows.push(Row::new(["New box...", "", "", "", ""]));
+                rows.push(Row::new(["New box...", "", "", "", "", ""]));
 
                 // Session rows
                 for (i, s) in items.iter().enumerate() {
@@ -202,6 +202,7 @@ where
                         status,
                         s.project_dir.as_str(),
                         s.image.as_str(),
+                        s.command.as_str(),
                         s.created_at.as_str(),
                     ]);
                     let row_idx = i + 1; // offset by "new session" row
@@ -217,6 +218,7 @@ where
                     Constraint::Min(10),
                     Constraint::Min(30),
                     Constraint::Min(20),
+                    Constraint::Min(15),
                     Constraint::Min(22),
                 ];
 


### PR DESCRIPTION
## Summary
- Add `command` field to `SessionSummary` struct, reading the null-byte-separated command file and joining with spaces
- Add CMD column to the TUI table (between IMAGE and CREATED) with `Constraint::Min(15)` width
- Bump version to v0.0.2

## Test plan
- [x] `cargo build` compiles without errors
- [x] `cargo test` — all 106 tests pass
- [x] `cargo clippy` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)