### PR TITLE
Show session names on tab completion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "box-cli"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "box-cli"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2021"
 description = "Sandboxed Docker environments for git repos"
 license = "MIT"

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
         box = pkgs.rustPlatform.buildRustPackage {
           pname = "box";
-          version = "0.0.4";
+          version = "0.0.5";
 
           src = ./.;
 

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -227,7 +227,7 @@ pub fn run_container(cfg: &DockerRunConfig) -> Result<i32> {
 
     let args = build_run_args(cfg)?;
     eprintln!("\x1b[2mrunning container:\x1b[0m");
-    eprintln!("docker {}", shell_words::join(&args));
+    eprintln!("docker {}\n", shell_words::join(&args));
 
     if cfg.detach {
         let output = Command::new("docker").args(&args).output()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -405,17 +405,7 @@ _box() {{
 
     case $state in
         subcmd)
-            local -a subcmds
-            subcmds=(
-                'create:Create a new session'
-                'resume:Resume an existing session'
-                'remove:Remove a session'
-                'stop:Stop a running session'
-                'path:Print workspace path for a session'
-                'upgrade:Self-update to the latest version'
-                'config:Output shell configuration'
-            )
-            _describe 'command' subcmds
+            __box_sessions
             ;;
         args)
             case $words[1] in
@@ -466,7 +456,11 @@ fn cmd_config_bash() -> Result<i32> {
     local session_cmds="resume remove stop path"
 
     if [[ $cword -eq 1 ]]; then
-        COMPREPLY=($(compgen -W "$subcommands" -- "$cur"))
+        local sessions=""
+        if [[ -d "$HOME/.box/sessions" ]]; then
+            sessions=$(command ls "$HOME/.box/sessions" 2>/dev/null)
+        fi
+        COMPREPLY=($(compgen -W "$sessions" -- "$cur"))
         return
     fi
 


### PR DESCRIPTION
## Summary
- `box <TAB>` now completes session names instead of subcommands, matching the bare name shortcut (`box <name>`)
- Added extra linebreak after the docker command output when starting a session

## Test plan
- [ ] Run `eval "$(box config zsh)"` then `box <TAB>` — verify session names appear
- [ ] Run `eval "$(box config bash)"` then `box <TAB>` — verify session names appear
- [ ] Start a session and verify blank line appears after the `docker ...` command

🤖 Generated with [Claude Code](https://claude.com/claude-code)