### PR TITLE
Fix bare name shortcut ignoring command after --

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "box-cli"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "box-cli"
-version = "0.0.5"
+version = "0.0.6"
 edition = "2021"
 description = "Sandboxed Docker environments for git repos"
 license = "MIT"

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
         box = pkgs.rustPlatform.buildRustPackage {
           pname = "box";
-          version = "0.0.5";
+          version = "0.0.6";
 
           src = ./.;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,7 +152,14 @@ fn main() {
         Some(Commands::External(args)) => {
             let name = args[0].to_string_lossy().to_string();
             let docker_args = std::env::var("BOX_DOCKER_ARGS").unwrap_or_default();
-            cmd_create(&name, None, &docker_args, None, true, false)
+            let cmd: Vec<String> = args[1..]
+                .iter()
+                .skip_while(|a| *a != "--")
+                .skip(1)
+                .map(|a| a.to_string_lossy().to_string())
+                .collect();
+            let cmd = if cmd.is_empty() { None } else { Some(cmd) };
+            cmd_create(&name, None, &docker_args, cmd, true, false)
         }
         None => cmd_list(),
     };


### PR DESCRIPTION
## Summary
- `box <name> -- <cmd>` was ignoring the command argument, always passing `None` to `cmd_create`
- Parse remaining args after `--` in the `External` (bare name shortcut) handler so it matches the behavior of `box create <name> -- <cmd>`
- Bump version to v0.0.6

## Test plan
- [ ] Verify `box test-1 -- zsh` launches a session with `zsh` as the command
- [ ] Verify `box test-1` (without `--`) still works as before
- [ ] `cargo test` passes (104 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)