### PR TITLE
Add exec subcommand to run commands in running sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "box-cli"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "box-cli"
-version = "0.0.6"
+version = "0.0.7"
 edition = "2021"
 description = "Sandboxed Docker environments for git repos"
 license = "MIT"

--- a/README.ja.md
+++ b/README.ja.md
@@ -110,6 +110,7 @@ box <name>                                        `box create <name>` のショ�
 box create <name> [options] [-- cmd...]           新しいセッションを作成
 box resume <name> [-d] [--docker-args <args>]     既存のセッションを再開
 box stop <name>                                   実行中のセッションを停止
+box exec <name> -- <cmd...>                       実行中のセッションでコマンドを実行
 box remove <name>                                 セッションを削除
 box path <name>                                   ワークスペースパスを表示
 box config zsh|bash                               シェル補完を出力
@@ -162,6 +163,16 @@ box resume my-feature
 box resume my-feature -d
 
 # 停止せずにデタッチ: Ctrl+P, Ctrl+Q
+```
+
+### 実行中のセッションでコマンドを実行
+
+```bash
+# 実行中のセッションでコマンドを実行
+box exec my-feature -- ls -la
+
+# 実行中のセッションでシェルを開く
+box exec my-feature -- bash
 ```
 
 ### 停止と削除

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ box <name>                                        Shortcut for `box create <name
 box create <name> [options] [-- cmd...]           Create a new session
 box resume <name> [-d] [--docker-args <args>]     Resume an existing session
 box stop <name>                                   Stop a running session
+box exec <name> -- <cmd...>                       Run a command in a running session
 box remove <name>                                 Remove a session
 box path <name>                                   Print workspace path
 box config zsh|bash                               Output shell completions
@@ -162,6 +163,16 @@ box resume my-feature
 box resume my-feature -d
 
 # Detach without stopping: Ctrl+P, Ctrl+Q
+```
+
+### Run a command in a session
+
+```bash
+# Run a command in a running session
+box exec my-feature -- ls -la
+
+# Open a shell in a running session
+box exec my-feature -- bash
 ```
 
 ### Stop and remove

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
         box = pkgs.rustPlatform.buildRustPackage {
           pname = "box";
-          version = "0.0.6";
+          version = "0.0.7";
 
           src = ./.;
 

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -323,6 +323,25 @@ pub fn attach_container(name: &str) -> Result<i32> {
     Ok(status.code().unwrap_or(1))
 }
 
+pub fn exec_container(name: &str, cmd: &[String]) -> Result<i32> {
+    let mut args = vec![
+        "exec".to_string(),
+        "-it".to_string(),
+        format!("box-{}", name),
+    ];
+    args.extend(cmd.iter().cloned());
+
+    let status = Command::new("docker")
+        .args(&args)
+        .stdin(std::process::Stdio::inherit())
+        .stdout(std::process::Stdio::inherit())
+        .stderr(std::process::Stdio::inherit())
+        .status()?;
+    restore_terminal();
+
+    Ok(status.code().unwrap_or(1))
+}
+
 pub fn start_container_detached(name: &str) -> Result<i32> {
     let status = Command::new("docker")
         .args(["start", &format!("box-{}", name)])

--- a/src/session.rs
+++ b/src/session.rs
@@ -47,7 +47,7 @@ pub fn sessions_dir() -> Result<PathBuf> {
 }
 
 const RESERVED_NAMES: &[&str] = &[
-    "create", "resume", "remove", "stop", "upgrade", "path", "config",
+    "create", "resume", "remove", "stop", "exec", "upgrade", "path", "config",
 ];
 
 pub fn validate_name(name: &str) -> Result<()> {


### PR DESCRIPTION
## Summary
- Add `box exec <name> -- <cmd...>` subcommand to run commands in running session containers via `docker exec`
- Update shell completions (Zsh and Bash) with exec support
- Update README (EN and JA) with usage docs

## Test plan
- [x] `cargo build` succeeds
- [x] `cargo clippy` passes with no warnings
- [x] `cargo test` — all 107 tests pass (3 new exec tests)
- [ ] Manual: `box exec <session> -- echo hello` runs command in a running session
- [ ] Manual: `box exec <session> -- bash` opens interactive shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)