### PR TITLE
Add list subcommand with filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "box-cli"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "box-cli"
-version = "0.0.7"
+version = "0.0.8"
 edition = "2021"
 description = "Sandboxed Docker environments for git repos"
 license = "MIT"

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
         box = pkgs.rustPlatform.buildRustPackage {
           pname = "box";
-          version = "0.0.7";
+          version = "0.0.8";
 
           src = ./.;
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -47,7 +47,7 @@ pub fn sessions_dir() -> Result<PathBuf> {
 }
 
 const RESERVED_NAMES: &[&str] = &[
-    "create", "resume", "remove", "stop", "exec", "upgrade", "path", "config",
+    "create", "resume", "remove", "stop", "exec", "upgrade", "path", "config", "list", "ls",
 ];
 
 pub fn validate_name(name: &str) -> Result<()> {


### PR DESCRIPTION
## Summary
- Add `box list` (alias `box ls`) subcommand for non-interactive session listing
- Supports `--running`/`-r` and `--stopped`/`-s` filters, and `--quiet`/`-q` mode for scripting (e.g. `box stop $(box list -q --running)`)
- Prints a formatted table with NAME, STATUS, IMAGE, PROJECT, COMMAND, CREATED columns; shortens `$HOME` to `~` in project paths
- Adds `list`/`ls` to reserved session names, updates Zsh/Bash shell completions, and includes 8 CLI parsing tests

## Test plan
- [x] `cargo build` compiles without errors
- [x] `cargo test` — all 115 tests pass (8 new)
- [x] `cargo clippy` — no warnings
- [ ] Manual: `box list`, `box ls`, `box list -q`, `box list --running`, `box list --stopped`, `box list -q --running`

🤖 Generated with [Claude Code](https://claude.com/claude-code)