### PR TITLE
Auto-resume existing session with bare name shortcut

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "box-cli"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "box-cli"
-version = "0.0.8"
+version = "0.0.9"
 edition = "2021"
 description = "Sandboxed Docker environments for git repos"
 license = "MIT"

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
         box = pkgs.rustPlatform.buildRustPackage {
           pname = "box";
-          version = "0.0.8";
+          version = "0.0.9";
 
           src = ./.;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -182,14 +182,18 @@ fn main() {
         Some(Commands::External(args)) => {
             let name = args[0].to_string_lossy().to_string();
             let docker_args = std::env::var("BOX_DOCKER_ARGS").unwrap_or_default();
-            let cmd: Vec<String> = args[1..]
-                .iter()
-                .skip_while(|a| *a != "--")
-                .skip(1)
-                .map(|a| a.to_string_lossy().to_string())
-                .collect();
-            let cmd = if cmd.is_empty() { None } else { Some(cmd) };
-            cmd_create(&name, None, &docker_args, cmd, true, false)
+            if session::session_exists(&name).unwrap_or(false) {
+                cmd_resume(&name, &docker_args, false)
+            } else {
+                let cmd: Vec<String> = args[1..]
+                    .iter()
+                    .skip_while(|a| *a != "--")
+                    .skip(1)
+                    .map(|a| a.to_string_lossy().to_string())
+                    .collect();
+                let cmd = if cmd.is_empty() { None } else { Some(cmd) };
+                cmd_create(&name, None, &docker_args, cmd, true, false)
+            }
         }
         None => cmd_list(),
     };


### PR DESCRIPTION
## Summary
- `box <name>` now automatically resumes the session if it already exists, instead of erroring with "Session already exists"
- If no session exists, it creates a new one as before
- Bump version to v0.0.9

## Test plan
- [ ] Run `box <name>` for a non-existing session — should create it
- [ ] Run `box <name>` again for the same session — should resume it (previously errored)
- [ ] `box create <name>` still errors if session exists (explicit create unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)