### PR TITLE
Fix resume rendering by sending SIGWINCH after docker attach

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,12 +108,13 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "box-cli"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "chrono",
  "clap",
  "crossterm",
+ "libc",
  "ratatui",
  "self_update",
  "shell-words",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "box-cli"
-version = "0.0.8"
+version = "0.0.9"
 edition = "2021"
 description = "Sandboxed Docker environments for git repos"
 license = "MIT"
@@ -15,6 +15,7 @@ clap = { version = "4", features = ["derive", "env"] }
 anyhow = "1"
 chrono = { version = "0.4", features = ["clock"], default-features = false }
 shell-words = "1"
+libc = "0.2"
 ratatui = "0.29"
 crossterm = "0.28"
 self_update = { version = "0.42", default-features = false, features = ["rustls"] }

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
         box = pkgs.rustPlatform.buildRustPackage {
           pname = "box";
-          version = "0.0.8";
+          version = "0.0.9";
 
           src = ./.;
 


### PR DESCRIPTION
## Summary
- Fix stale terminal dimensions when reattaching to a container by sending `SIGWINCH` to the `docker attach` process after a short delay
- This causes Docker to re-read the current terminal size and push a resize event to the container, eliminating the need for a manual pane resize
- Adds `libc` dependency for the `kill` syscall
- Bumps version to 0.0.9

## Test plan
- [ ] Run `box <name>` to create and enter a session, then detach and reattach — verify the terminal renders correctly without manual resizing
- [ ] Verify behavior on terminals of different sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)