### PR TITLE
Add "c" keybinding to cd to session project directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "box-cli"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "box-cli"
-version = "0.0.9"
+version = "0.0.10"
 edition = "2021"
 description = "Sandboxed Docker environments for git repos"
 license = "MIT"

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
         box = pkgs.rustPlatform.buildRustPackage {
           pname = "box";
-          version = "0.0.9";
+          version = "0.0.10";
 
           src = ./.;
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -17,6 +17,7 @@ pub enum TuiAction {
         image: Option<String>,
         command: Option<Vec<String>>,
     },
+    Cd(String),
     Quit,
 }
 
@@ -242,7 +243,7 @@ where
                     } else if on_new_row || items.is_empty() {
                         Line::from("[Enter] New  [q] Quit").style(Style::default().dim())
                     } else {
-                        Line::from("[Enter] Resume  [d] Delete  [q] Quit")
+                        Line::from("[Enter] Resume  [c] Cd  [d] Delete  [q] Quit")
                             .style(Style::default().dim())
                     }
                 }
@@ -296,6 +297,15 @@ where
                                     let name = items[i - 1].name.clone();
                                     clear_viewport(&mut terminal, viewport_height)?;
                                     return Ok(TuiAction::Resume(name));
+                                }
+                            }
+                        }
+                        KeyCode::Char('c') => {
+                            if let Some(i) = state.selected() {
+                                if i != new_row_idx {
+                                    let name = items[i - 1].name.clone();
+                                    clear_viewport(&mut terminal, viewport_height)?;
+                                    return Ok(TuiAction::Cd(name));
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary
- Add `c` keybinding in the TUI session manager to print the selected session's `project_dir` to stdout and exit
- Handle new `TuiAction::Cd` variant in `cmd_list()` to print the directory path
- Update footer hints to show the new `[c] Cd` option on session rows
- Bump version to v0.0.10

## Test plan
- [x] `cargo build` compiles without errors
- [x] `cargo clippy` passes with no warnings
- [x] `cargo test` — all 115 tests pass
- [ ] Manual: run `box`, select a session, press `c` — TUI exits and prints the project directory
- [ ] Manual: verify `cd "$(box)"` changes the shell's working directory to the session's project dir

🤖 Generated with [Claude Code](https://claude.com/claude-code)