### PR TITLE
Shorten project paths, reorder columns, update READMEs for list/cd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "box-cli"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "box-cli"
-version = "0.0.10"
+version = "0.0.11"
 edition = "2021"
 description = "Sandboxed Docker environments for git repos"
 license = "MIT"

--- a/README.ja.md
+++ b/README.ja.md
@@ -111,7 +111,9 @@ box create <name> [options] [-- cmd...]           新しいセッションを作
 box resume <name> [-d] [--docker-args <args>]     既存のセッションを再開
 box stop <name>                                   実行中のセッションを停止
 box exec <name> -- <cmd...>                       実行中のセッションでコマンドを実行
+box list [options]                                セッション一覧を表示（エイリアス: ls）
 box remove <name>                                 セッションを削除
+box cd <name>                                     ホストのプロジェクトディレクトリを表示
 box path <name>                                   ワークスペースパスを表示
 box config zsh|bash                               シェル補完を出力
 box upgrade                                       最新版にアップグレード
@@ -122,15 +124,16 @@ box upgrade                                       最新版にアップグレー
 引数なしで `box` を実行すると、対話型TUIが開きます：
 
 ```
- NAME            STATUS   PROJECT                   IMAGE            CREATED
+ NAME            PROJECT      STATUS   CMD      IMAGE            CREATED
   New box...
-> my-feature     running  /Users/you/projects/app   alpine:latest    2026-02-07 12:00:00 UTC
-  test                    /Users/you/projects/other  ubuntu:latest   2026-02-07 12:30:00 UTC
+> my-feature     /U/y/p/app   running  claude   alpine:latest    2026-02-07 12:00:00 UTC
+  test           /U/y/p/other                   ubuntu:latest    2026-02-07 12:30:00 UTC
 
- [Enter] Resume  [d] Delete  [q] Quit
+ [Enter] Resume  [c] Cd  [d] Delete  [q] Quit
 ```
 
 - **Enter** でセッションを再開、または「New box...」で新規作成
+- **c** でセッションのホストプロジェクトディレクトリにcd
 - **d** でハイライト中のセッションを削除（確認あり）
 - **q** / **Esc** で終了
 
@@ -175,6 +178,38 @@ box exec my-feature -- ls -la
 box exec my-feature -- bash
 ```
 
+### セッション一覧の表示
+
+```bash
+# 全セッションを一覧表示
+box list
+
+# エイリアス
+box ls
+
+# 実行中のセッションのみ表示
+box list --running
+
+# 停止中のセッションのみ表示
+box list --stopped
+
+# クワイエットモード — 名前のみ出力（スクリプト用途に便利）
+box list -q --running
+
+# 例: 実行中の全セッションを停止
+box stop $(box list -q --running)
+```
+
+### プロジェクトディレクトリへのcd
+
+```bash
+# セッションのホストプロジェクトディレクトリを表示
+box cd my-feature
+
+# シェル補完を有効にしている場合、プロジェクトディレクトリにcd
+cd "$(box cd my-feature)"
+```
+
 ### 停止と削除
 
 ```bash
@@ -196,6 +231,14 @@ box remove my-feature
 | `--docker-args <args>` | 追加のDockerフラグ（例: `-e KEY=VALUE`、`-v /host:/container`）。`$BOX_DOCKER_ARGS` を上書き |
 | `--no-ssh` | SSHエージェント転送を無効化（デフォルトは有効） |
 | `-- cmd...` | コンテナで実行するコマンド（デフォルト: `$BOX_DEFAULT_CMD` が設定されている場合はそれを使用） |
+
+### `box list`
+
+| オプション | 説明 |
+|--------|-------------|
+| `--running`, `-r` | 実行中のセッションのみ表示 |
+| `--stopped`, `-s` | 停止中のセッションのみ表示 |
+| `--quiet`, `-q` | セッション名のみ出力（スクリプト用途に便利） |
 
 ### `box resume`
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,9 @@ box create <name> [options] [-- cmd...]           Create a new session
 box resume <name> [-d] [--docker-args <args>]     Resume an existing session
 box stop <name>                                   Stop a running session
 box exec <name> -- <cmd...>                       Run a command in a running session
+box list [options]                                List sessions (alias: ls)
 box remove <name>                                 Remove a session
+box cd <name>                                     Print host project directory
 box path <name>                                   Print workspace path
 box config zsh|bash                               Output shell completions
 box upgrade                                       Upgrade to latest version
@@ -122,15 +124,16 @@ box upgrade                                       Upgrade to latest version
 Running `box` with no arguments opens an interactive TUI:
 
 ```
- NAME            STATUS   PROJECT                   IMAGE            CREATED
+ NAME            PROJECT      STATUS   CMD      IMAGE            CREATED
   New box...
-> my-feature     running  /Users/you/projects/app   alpine:latest    2026-02-07 12:00:00 UTC
-  test                    /Users/you/projects/other  ubuntu:latest   2026-02-07 12:30:00 UTC
+> my-feature     /U/y/p/app   running  claude   alpine:latest    2026-02-07 12:00:00 UTC
+  test           /U/y/p/other                   ubuntu:latest    2026-02-07 12:30:00 UTC
 
- [Enter] Resume  [d] Delete  [q] Quit
+ [Enter] Resume  [c] Cd  [d] Delete  [q] Quit
 ```
 
 - **Enter** on a session to resume it, or on "New box..." to create a new one
+- **c** to cd to the session's host project directory
 - **d** to delete the highlighted session (with confirmation)
 - **q** / **Esc** to quit
 
@@ -175,6 +178,38 @@ box exec my-feature -- ls -la
 box exec my-feature -- bash
 ```
 
+### List sessions
+
+```bash
+# List all sessions
+box list
+
+# Alias
+box ls
+
+# Show only running sessions
+box list --running
+
+# Show only stopped sessions
+box list --stopped
+
+# Quiet mode — names only (useful for scripting)
+box list -q --running
+
+# Example: stop all running sessions
+box stop $(box list -q --running)
+```
+
+### Cd to project directory
+
+```bash
+# Print the host project directory for a session
+box cd my-feature
+
+# With shell completions enabled, cd to the project directory
+cd "$(box cd my-feature)"
+```
+
 ### Stop and remove
 
 ```bash
@@ -196,6 +231,14 @@ box remove my-feature
 | `--docker-args <args>` | Extra Docker flags (e.g. `-e KEY=VALUE`, `-v /host:/container`). Overrides `$BOX_DOCKER_ARGS` |
 | `--no-ssh` | Disable SSH agent forwarding (enabled by default) |
 | `-- cmd...` | Command to run in container (default: `$BOX_DEFAULT_CMD` if set) |
+
+### `box list`
+
+| Option | Description |
+|--------|-------------|
+| `--running`, `-r` | Show only running sessions |
+| `--stopped`, `-s` | Show only stopped sessions |
+| `--quiet`, `-q` | Only print session names (useful for scripting) |
 
 ### `box resume`
 

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
         box = pkgs.rustPlatform.buildRustPackage {
           pname = "box";
-          version = "0.0.10";
+          version = "0.0.11";
 
           src = ./.;
 


### PR DESCRIPTION
## Summary
- Add `shorten_project_path()` to abbreviate intermediate path components for display (e.g. `/Users/yusuke/projects/app` => `~/p/app`), applied in both `box list` and the TUI
- Reorder columns to NAME, PROJECT, STATUS, CMD, IMAGE, CREATED in both `box list` and TUI
- Update README.md and README.ja.md with documentation for `box list`/`box ls` and `box cd` commands, including options tables and usage examples

## Test plan
- [x] `cargo build` compiles without errors
- [x] `cargo clippy` passes with no warnings
- [x] `cargo test` — all 117 tests pass
- [ ] Manual: `box list` shows shortened project paths and new column order
- [ ] Manual: TUI (`box`) shows shortened project paths and new column order

🤖 Generated with [Claude Code](https://claude.com/claude-code)