### PR TITLE
Use fixed column widths in TUI table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "box-cli"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "box-cli"
-version = "0.0.12"
+version = "0.0.13"
 edition = "2021"
 description = "Sandboxed Docker environments for git repos"
 license = "MIT"

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
         box = pkgs.rustPlatform.buildRustPackage {
           pname = "box";
-          version = "0.0.12";
+          version = "0.0.13";
 
           src = ./.;
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -220,11 +220,11 @@ where
                 }
 
                 let widths = [
-                    Constraint::Min(15),
-                    Constraint::Min(30),
-                    Constraint::Min(10),
-                    Constraint::Min(15),
-                    Constraint::Min(20),
+                    Constraint::Length(15),
+                    Constraint::Length(30),
+                    Constraint::Length(10),
+                    Constraint::Length(15),
+                    Constraint::Length(20),
                     Constraint::Min(22),
                 ];
 


### PR DESCRIPTION
## Summary
- Change TUI table columns (NAME, PROJECT, STATUS, CMD, IMAGE) from `Constraint::Min` to `Constraint::Length` so they stay at fixed widths instead of expanding evenly across the terminal
- Keep only the last column (CREATED) as `Constraint::Min(22)` so it absorbs remaining space, acting as `flex:1`
- This prevents the table from looking too scattered on wide terminals

## Test plan
- [ ] Open `box` TUI on a wide terminal and verify columns are compact/left-aligned
- [ ] Verify the CREATED column stretches to fill remaining space
- [ ] Verify columns still render correctly on narrow terminals

🤖 Generated with [Claude Code](https://claude.com/claude-code)