### PR TITLE
Remove --no-ssh flag and SSH agent forwarding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "box-cli"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "box-cli"
-version = "0.0.13"
+version = "0.0.14"
 edition = "2021"
 description = "Sandboxed Docker environments for git repos"
 license = "MIT"

--- a/README.ja.md
+++ b/README.ja.md
@@ -229,7 +229,6 @@ box remove my-feature
 | `-d` | バックグラウンドでコンテナを実行（デタッチ） |
 | `--image <image>` | 使用するDockerイメージ（デフォルト: `alpine:latest`） |
 | `--docker-args <args>` | 追加のDockerフラグ（例: `-e KEY=VALUE`、`-v /host:/container`）。`$BOX_DOCKER_ARGS` を上書き |
-| `--no-ssh` | SSHエージェント転送を無効化（デフォルトは有効） |
 | `-- cmd...` | コンテナで実行するコマンド（デフォルト: `$BOX_DEFAULT_CMD` が設定されている場合はそれを使用） |
 
 ### `box list`
@@ -325,37 +324,12 @@ gitの隔離戦略はいくつか存在しますが、それぞれに問題が�
 
 - **自分のツールチェーンを使用** — 必要な言語、ランタイム、ツールを含む任意のDockerイメージを使用可能
 - **永続的なセッション** — 終了しても再開可能、ファイルと状態が保持される
-- **SSHエージェント転送** — ホストのSSH鍵で `git push` / `git pull` がそのまま動作
 - **完全なDocker制御** — カスタムネットワーク、ボリューム、環境変数、その他の `docker run` フラグが使用可能
 - **任意のエージェントで動作** — 特定のツールに縛られず、Claude Code、Cursor、Copilot、手動操作で使用可能
 
 素のDockerを使うことで完全な制御を維持しつつ、Boxが隔離とライフサイクルを管理します。
 
 </details>
-
-## SSHエージェント転送
-
-**課題**: Dockerコンテナは通常、ホストのSSH鍵にアクセスできません。macOSではさらに困難です — DockerがVM内で動作するため、UnixソケットがVM境界を越えられません。
-
-**boxの解決策**: ホストのSSHエージェントをコンテナに自動転送します。`git push`、`git pull`、`ssh` がすべて既存の鍵で動作します — 鍵のコピーは不要です。
-
-**プラットフォーム別の仕組み**:
-
-- **macOS**（Docker Desktop / OrbStack）: VM経由のソケット `/run/host-services/ssh-auth.sock` をマウント
-- **Linux**: `$SSH_AUTH_SOCK` を直接コンテナにマウント
-
-Boxはクローンしたリポジトリの `origin` リモートを実際のURL（ローカルクローンパスではなく）に自動修正するため、`git push origin` がそのまま動作します。
-
-```bash
-box create my-feature --image ubuntu:latest -- bash
-
-# コンテナ内で
-ssh-add -l          # 鍵の一覧が表示されるはずです
-git push origin main
-
-# SSH転送を無効にする場合
-box create my-feature --no-ssh -- bash
-```
 
 ## Claude Code連携
 

--- a/README.md
+++ b/README.md
@@ -229,7 +229,6 @@ box remove my-feature
 | `-d` | Run container in the background (detached) |
 | `--image <image>` | Docker image to use (default: `alpine:latest`) |
 | `--docker-args <args>` | Extra Docker flags (e.g. `-e KEY=VALUE`, `-v /host:/container`). Overrides `$BOX_DOCKER_ARGS` |
-| `--no-ssh` | Disable SSH agent forwarding (enabled by default) |
 | `-- cmd...` | Command to run in container (default: `$BOX_DEFAULT_CMD` if set) |
 
 ### `box list`
@@ -325,37 +324,12 @@ Some tools (e.g. Claude Code's `--sandbox`) provide built-in Docker sandboxing. 
 
 - **Your own toolchain** — use any Docker image with the exact languages, runtimes, and tools you need
 - **Persistent sessions** — exit and resume where you left off; files and state are preserved
-- **SSH agent forwarding** — `git push` / `git pull` with your host SSH keys, out of the box
 - **Full Docker control** — custom network, volumes, env vars, and any other `docker run` flags
 - **Works with any agent** — not tied to a specific tool; use Claude Code, Cursor, Copilot, or manual workflows
 
 Plain Docker gives full control while box handles the isolation and lifecycle.
 
 </details>
-
-## SSH Agent Forwarding
-
-**The problem**: Docker containers can't normally access your host SSH keys. On macOS it's even harder — Docker runs in a VM, so Unix sockets can't cross the VM boundary.
-
-**What box does**: Automatically forwards the host's SSH agent into the container. `git push`, `git pull`, and `ssh` all work with your existing keys — no key copying needed.
-
-**How it works per platform**:
-
-- **macOS** (Docker Desktop / OrbStack): Mounts the VM-bridged socket at `/run/host-services/ssh-auth.sock`
-- **Linux**: Mounts `$SSH_AUTH_SOCK` directly into the container
-
-Box also re-points the cloned repo's `origin` remote to the real URL (not the local clone path), so `git push origin` works out of the box.
-
-```bash
-box create my-feature --image ubuntu:latest -- bash
-
-# Inside the container
-ssh-add -l          # should list your keys
-git push origin main
-
-# To disable SSH forwarding
-box create my-feature --no-ssh -- bash
-```
 
 ## Security Note
 

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
         box = pkgs.rustPlatform.buildRustPackage {
           pname = "box";
-          version = "0.0.13";
+          version = "0.0.14";
 
           src = ./.;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,7 +19,6 @@ pub struct BoxConfig {
     pub mount_path: String,
     pub command: Vec<String>,
     pub env: Vec<String>,
-    pub ssh: bool,
 }
 
 pub struct BoxConfigInput {
@@ -29,7 +28,6 @@ pub struct BoxConfigInput {
     pub project_dir: String,
     pub command: Option<Vec<String>>,
     pub env: Vec<String>,
-    pub ssh: bool,
 }
 
 pub fn resolve(input: BoxConfigInput) -> Result<BoxConfig> {
@@ -55,7 +53,6 @@ pub fn resolve(input: BoxConfigInput) -> Result<BoxConfig> {
         mount_path,
         command,
         env: input.env,
-        ssh: input.ssh,
     })
 }
 
@@ -121,7 +118,6 @@ mod tests {
             project_dir: "/home/user/myproject".to_string(),
             command: None,
             env: vec![],
-            ssh: false,
         })
         .unwrap();
 
@@ -134,7 +130,6 @@ mod tests {
                 mount_path: "/workspace/myproject".to_string(),
                 command: vec![],
                 env: vec![],
-                ssh: false,
             }
         );
 
@@ -157,7 +152,6 @@ mod tests {
             project_dir: "/home/user/myproject".to_string(),
             command: None,
             env: vec![],
-            ssh: false,
         })
         .unwrap();
 
@@ -175,7 +169,6 @@ mod tests {
             project_dir: "/home/user/myproject".to_string(),
             command: None,
             env: vec![],
-            ssh: false,
         })
         .unwrap();
 
@@ -195,7 +188,6 @@ mod tests {
             project_dir: "/home/user/myproject".to_string(),
             command: None,
             env: vec![],
-            ssh: false,
         })
         .unwrap();
         assert_eq!(config.image, "ubuntu:latest");
@@ -218,7 +210,6 @@ mod tests {
             project_dir: "/home/user/myproject".to_string(),
             command: None,
             env: vec![],
-            ssh: false,
         })
         .unwrap();
         assert_eq!(config.image, "python:3.11");
@@ -278,7 +269,6 @@ mod tests {
             project_dir: "/home/user/project".to_string(),
             command: Some(vec!["python".to_string(), "main.py".to_string()]),
             env: vec!["FOO=bar".to_string()],
-            ssh: false,
         })
         .unwrap();
 
@@ -291,7 +281,6 @@ mod tests {
                 mount_path: "/app".to_string(),
                 command: vec!["python".to_string(), "main.py".to_string()],
                 env: vec!["FOO=bar".to_string()],
-                ssh: false,
             }
         );
     }
@@ -308,7 +297,6 @@ mod tests {
             project_dir: "/home/user/myproject".to_string(),
             command: None,
             env: vec![],
-            ssh: false,
         })
         .unwrap();
         assert_eq!(config.command, vec!["bash".to_string()]);
@@ -330,7 +318,6 @@ mod tests {
             project_dir: "/home/user/myproject".to_string(),
             command: Some(vec!["sh".to_string()]),
             env: vec![],
-            ssh: false,
         })
         .unwrap();
         assert_eq!(config.command, vec!["sh".to_string()]);
@@ -352,7 +339,6 @@ mod tests {
             project_dir: "/home/user/myproject".to_string(),
             command: None,
             env: vec![],
-            ssh: false,
         })
         .unwrap();
         assert_eq!(
@@ -381,7 +367,6 @@ mod tests {
             project_dir: "/home/user/myproject".to_string(),
             command: None,
             env: vec![],
-            ssh: false,
         })
         .unwrap();
         assert_eq!(config.command, Vec::<String>::new());
@@ -403,7 +388,6 @@ mod tests {
             project_dir: "/home/user/myproject".to_string(),
             command: None,
             env: vec![],
-            ssh: false,
         });
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("BOX_DEFAULT_CMD"));
@@ -425,7 +409,6 @@ mod tests {
             project_dir: "/home/user/myproject".to_string(),
             command: None,
             env: vec![],
-            ssh: false,
         })
         .unwrap();
         assert_eq!(config.command, Vec::<String>::new());
@@ -446,7 +429,6 @@ mod tests {
             project_dir: "/home/user/myproject".to_string(),
             command: Some(vec![]),
             env: vec![],
-            ssh: false,
         })
         .unwrap();
         assert_eq!(config.command, Vec::<String>::new());

--- a/src/session.rs
+++ b/src/session.rs
@@ -13,7 +13,6 @@ pub struct Session {
     pub mount_path: String,
     pub command: Vec<String>,
     pub env: Vec<String>,
-    pub ssh: bool,
 }
 
 impl From<config::BoxConfig> for Session {
@@ -25,7 +24,6 @@ impl From<config::BoxConfig> for Session {
             mount_path: cfg.mount_path,
             command: cfg.command,
             env: cfg.env,
-            ssh: cfg.ssh,
         }
     }
 }
@@ -99,12 +97,6 @@ pub fn save(session: &Session) -> Result<()> {
     } else {
         let _ = fs::remove_file(dir.join("env"));
     }
-    if session.ssh {
-        fs::write(dir.join("ssh"), "true")?;
-    } else {
-        let _ = fs::remove_file(dir.join("ssh"));
-    }
-
     Ok(())
 }
 
@@ -146,8 +138,6 @@ pub fn load(name: &str) -> Result<Session> {
         })
         .unwrap_or_default();
 
-    let ssh = dir.join("ssh").exists();
-
     Ok(Session {
         name: name.to_string(),
         project_dir,
@@ -155,7 +145,6 @@ pub fn load(name: &str) -> Result<Session> {
         mount_path,
         command,
         env,
-        ssh,
     })
 }
 
@@ -308,7 +297,6 @@ mod tests {
                 mount_path: "/workspace".to_string(),
                 command: vec![],
                 env: vec![],
-                ssh: false,
             };
             save(&sess).unwrap();
 
@@ -335,7 +323,6 @@ mod tests {
                     "echo hello".to_string(),
                 ],
                 env: vec![],
-                ssh: false,
             };
             save(&sess).unwrap();
 
@@ -354,7 +341,6 @@ mod tests {
                 mount_path: "/workspace".to_string(),
                 command: vec![],
                 env: vec![],
-                ssh: false,
             };
             save(&sess).unwrap();
 
@@ -418,7 +404,6 @@ mod tests {
                 mount_path: "/workspace".to_string(),
                 command: vec![],
                 env: vec![],
-                ssh: false,
             };
             save(&sess).unwrap();
             assert!(session_exists("exists-test").unwrap());
@@ -444,7 +429,6 @@ mod tests {
                     mount_path: "/workspace".to_string(),
                     command: vec![],
                     env: vec![],
-                    ssh: false,
                 };
                 save(&sess).unwrap();
             }
@@ -468,7 +452,6 @@ mod tests {
                 mount_path: "/workspace".to_string(),
                 command: vec![],
                 env: vec![],
-                ssh: false,
             };
             save(&sess).unwrap();
 
@@ -490,7 +473,6 @@ mod tests {
                 mount_path: "/workspace".to_string(),
                 command: vec![],
                 env: vec![],
-                ssh: false,
             };
             save(&sess).unwrap();
             assert!(session_exists("to-remove").unwrap());
@@ -518,7 +500,6 @@ mod tests {
                 mount_path: "/workspace".to_string(),
                 command: vec![],
                 env: vec![],
-                ssh: false,
             };
             save(&sess).unwrap();
 
@@ -556,7 +537,6 @@ mod tests {
                 mount_path: "/workspace".to_string(),
                 command: vec!["bash".to_string(), "-c".to_string(), "echo hi".to_string()],
                 env: vec![],
-                ssh: false,
             };
             save(&sess).unwrap();
 
@@ -576,7 +556,6 @@ mod tests {
                 mount_path: "/workspace".to_string(),
                 command: vec![],
                 env: vec!["FOO=bar".to_string(), "BAZ".to_string()],
-                ssh: false,
             };
             save(&sess).unwrap();
 
@@ -599,7 +578,6 @@ mod tests {
                 mount_path: "/workspace".to_string(),
                 command: vec![],
                 env: vec![],
-                ssh: false,
             };
             save(&sess).unwrap();
 


### PR DESCRIPTION
## Summary
- Remove `--no-ssh` CLI flag and all SSH agent forwarding logic (socket mounting, permission fixing, env vars)
- Remove `ssh` field from `BoxConfig`, `BoxConfigInput`, `Session`, and `DockerRunConfig` structs
- Remove SSH-related metadata persistence (read/write of `ssh` file in session directory)
- Remove SSH documentation sections from both READMEs and shell completions
- Bump version to v0.0.14

## Test plan
- [x] `cargo fmt` — no changes needed
- [x] `cargo clippy` — no warnings
- [x] `cargo build` — compiles successfully
- [x] `cargo test` — all 115 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)