### PR TITLE
Fix BOX_DEFAULT_CMD ignored in local mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "box-cli"
-version = "0.0.14"
+version = "0.0.16"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "box-cli"
-version = "0.0.15"
+version = "0.0.16"
 edition = "2021"
 description = "Sandboxed Docker environments for git repos"
 license = "MIT"

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
         box = pkgs.rustPlatform.buildRustPackage {
           pname = "box";
-          version = "0.0.15";
+          version = "0.0.16";
 
           src = ./.;
 


### PR DESCRIPTION
## Summary
- `config::resolve()` returned early for local sessions with an empty command, skipping the `BOX_DEFAULT_CMD` check entirely
- Extracted command resolution into `resolve_command()` helper, called before the local early-return so both local and Docker paths respect `BOX_DEFAULT_CMD`
- Added `test_resolve_local_respects_default_cmd` test

## Test plan
- [x] `cargo test` — 117 tests pass
- [x] `cargo clippy` — no warnings
- [ ] Set `BOX_MODE=local` and `BOX_DEFAULT_CMD=bash`, run `box <new-name>` and verify the command is saved

🤖 Generated with [Claude Code](https://claude.com/claude-code)