### PR TITLE
Execute BOX_DEFAULT_CMD in local mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "box-cli"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "box-cli"
-version = "0.0.16"
+version = "0.0.17"
 edition = "2021"
 description = "Sandboxed Docker environments for git repos"
 license = "MIT"

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
         box = pkgs.rustPlatform.buildRustPackage {
           pname = "box";
-          version = "0.0.16";
+          version = "0.0.17";
 
           src = ./.;
 


### PR DESCRIPTION
## Summary
- Add `run_local_command` helper that spawns a child process in the workspace directory
- Execute `BOX_DEFAULT_CMD` (or `-- cmd`) in local mode during both create and resume flows
- Print the command in session metadata output when creating local sessions

## Test plan
- [ ] `cargo fmt && cargo clippy` — no warnings
- [ ] `cargo test` — all 117 tests pass
- [ ] Set `BOX_DEFAULT_CMD=echo hello` and `BOX_MODE=local`, run `box test-session` — should print "hello"
- [ ] Resume the session — should print "hello" again

🤖 Generated with [Claude Code](https://claude.com/claude-code)