### PR TITLE
Add `box origin` subcommand and cd-back on remove

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "box-cli"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "box-cli"
-version = "0.0.17"
+version = "0.0.18"
 edition = "2021"
 description = "Sandboxed Docker environments for git repos"
 license = "MIT"

--- a/README.ja.md
+++ b/README.ja.md
@@ -119,6 +119,7 @@ box list [options]                                セッション一覧を表示
 box remove <name>                                 セッションを削除
 box cd <name>                                     ホストのプロジェクトディレクトリを表示
 box path <name>                                   ワークスペースパスを表示
+box origin                                        ワークスペースから元のプロジェクトディレクトリにcd
 box config zsh|bash                               シェル補完を出力
 box upgrade                                       最新版にアップグレード
 ```
@@ -134,11 +135,12 @@ box upgrade                                       最新版にアップグレー
   local-exp      /U/y/p/app   local                                      2026-02-07 12:15:00 UTC
   test           /U/y/p/other docker                    ubuntu:latest    2026-02-07 12:30:00 UTC
 
- [Enter] Resume  [c] Cd  [d] Delete  [q] Quit
+ [Enter] Resume  [c] Cd  [o] Origin  [d] Delete  [q] Quit
 ```
 
 - **Enter** でセッションを再開、または「New box...」で新規作成
-- **c** でセッションのホストプロジェクトディレクトリにcd
+- **c** でセッションのワークスペースディレクトリにcd
+- **o** でセッションの元のプロジェクトディレクトリにcd
 - **d** でハイライト中のセッションを削除（確認あり）
 - **q** / **Esc** で終了
 
@@ -216,6 +218,13 @@ box cd my-feature
 
 # シェル補完を有効にしている場合、プロジェクトディレクトリにcd
 cd "$(box cd my-feature)"
+```
+
+### 元のプロジェクトに移動
+
+```bash
+# ワークスペース内から、元のプロジェクトディレクトリにcd
+box origin
 ```
 
 ### 停止と削除

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ box list [options]                                List sessions (alias: ls)
 box remove <name>                                 Remove a session
 box cd <name>                                     Print host project directory
 box path <name>                                   Print workspace path
+box origin                                        Cd back to origin project from workspace
 box config zsh|bash                               Output shell completions
 box upgrade                                       Upgrade to latest version
 ```
@@ -134,11 +135,12 @@ Running `box` with no arguments opens an interactive TUI:
   local-exp      /U/y/p/app   local                                      2026-02-07 12:15:00 UTC
   test           /U/y/p/other docker                    ubuntu:latest    2026-02-07 12:30:00 UTC
 
- [Enter] Resume  [c] Cd  [d] Delete  [q] Quit
+ [Enter] Resume  [c] Cd  [o] Origin  [d] Delete  [q] Quit
 ```
 
 - **Enter** on a session to resume it, or on "New box..." to create a new one
-- **c** to cd to the session's host project directory
+- **c** to cd to the session's workspace directory
+- **o** to cd to the session's origin project directory
 - **d** to delete the highlighted session (with confirmation)
 - **q** / **Esc** to quit
 
@@ -216,6 +218,13 @@ box cd my-feature
 
 # With shell completions enabled, cd to the project directory
 cd "$(box cd my-feature)"
+```
+
+### Navigate to origin project
+
+```bash
+# From inside a workspace, cd back to the origin project directory
+box origin
 ```
 
 ### Stop and remove

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
         box = pkgs.rustPlatform.buildRustPackage {
           pname = "box";
-          version = "0.0.17";
+          version = "0.0.18";
 
           src = ./.;
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -20,6 +20,7 @@ pub enum TuiAction {
         local: bool,
     },
     Cd(String),
+    Origin(String),
     Quit,
 }
 
@@ -254,7 +255,7 @@ where
                     } else if on_new_row || items.is_empty() {
                         Line::from("[Enter] New  [q] Quit").style(Style::default().dim())
                     } else {
-                        Line::from("[Enter] Resume  [c] Cd  [d] Delete  [q] Quit")
+                        Line::from("[Enter] Resume  [c] Cd  [o] Origin  [d] Delete  [q] Quit")
                             .style(Style::default().dim())
                     }
                 }
@@ -321,6 +322,15 @@ where
                                     let name = items[i - 1].name.clone();
                                     clear_viewport(&mut terminal, viewport_height)?;
                                     return Ok(TuiAction::Cd(name));
+                                }
+                            }
+                        }
+                        KeyCode::Char('o') => {
+                            if let Some(i) = state.selected() {
+                                if i != new_row_idx {
+                                    let name = items[i - 1].name.clone();
+                                    clear_viewport(&mut terminal, viewport_height)?;
+                                    return Ok(TuiAction::Origin(name));
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary
- Add `box origin` subcommand to navigate from a workspace directory back to the original project directory
- `box remove` now automatically cds back to the project directory when run from inside the workspace being removed
- Add TUI `o` keyboard shortcut to cd to a session's origin project directory
- Update bash/zsh shell completions and README (en/ja)

## Test plan
- [ ] Run `box create test1 --local`, then `box origin` — should cd to project dir
- [ ] Run `box remove test1` from workspace dir — should cd back to project dir
- [ ] Open TUI (`box`), select a session, press `o` — should cd to origin project
- [ ] Run `box origin` outside a workspace — should show error message
- [ ] Verify `cargo test` passes (117 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)