### PR TITLE
Ask for command in TUI local mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "box-cli"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "box-cli"
-version = "0.0.18"
+version = "0.0.19"
 edition = "2021"
 description = "Sandboxed Docker environments for git repos"
 license = "MIT"

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
         box = pkgs.rustPlatform.buildRustPackage {
           pname = "box";
-          version = "0.0.18";
+          version = "0.0.19";
 
           src = ./.;
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -173,6 +173,7 @@ where
     let mut footer_msg = String::new();
     let mut new_name = String::new();
     let mut new_image: Option<String> = None;
+    let mut new_local = false;
 
     loop {
         terminal.draw(|f| {
@@ -394,13 +395,12 @@ where
                             .map(|v| v == "local")
                             .unwrap_or(false)
                         {
-                            clear_viewport(&mut terminal, viewport_height)?;
-                            return Ok(TuiAction::New {
-                                name,
-                                image: None,
-                                command: None,
-                                local: true,
-                            });
+                            new_name = name;
+                            new_image = None;
+                            new_local = true;
+                            let default_cmd = std::env::var("BOX_DEFAULT_CMD").unwrap_or_default();
+                            input = TextInput::with_text(default_cmd);
+                            mode = Mode::InputCommand;
                         } else {
                             new_name = name;
                             let default_image = std::env::var("BOX_DEFAULT_IMAGE")
@@ -456,7 +456,7 @@ where
                             name: new_name,
                             image: new_image,
                             command,
-                            local: false,
+                            local: new_local,
                         });
                     }
                     KeyCode::Esc => {


### PR DESCRIPTION
## Summary
- TUI in local mode (`BOX_MODE=local`) now prompts for a command instead of skipping the input entirely
- Skips only the Docker image prompt (not needed for local mode) while still showing the command prompt with `BOX_DEFAULT_CMD` pre-filled
- If the command is left empty, no command is executed (just `cd` to workspace)

## Test plan
- [ ] Run `BOX_MODE=local box` and create a new session — verify the command prompt appears
- [ ] Leave command empty — verify it creates the session without running anything
- [ ] Enter a command — verify it runs in the workspace
- [ ] Verify Docker mode TUI flow is unchanged (image + command prompts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)