### PR TITLE
Add preset feature for named repo groups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "box-cli"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "box-cli"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 description = "Sandboxed git workspaces for development"
 license = "MIT"

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
         box = pkgs.rustPlatform.buildRustPackage {
           pname = "box";
-          version = "0.1.10";
+          version = "0.1.11";
 
           src = ./.;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod config;
 mod git;
+mod preset;
 mod repo;
 mod session;
 #[cfg(test)]
@@ -17,7 +18,7 @@ use std::path::{Path, PathBuf};
 #[command(
     name = "box",
     about = "Sandboxed git workspaces for development",
-    after_help = "Examples:\n  box                                         # interactive session manager\n  box new my-feature --repo app-a              # create a new session\n  box new my-feature --repo app-a --repo app-b # select specific repos\n  box new my-feature --repo app --strategy worktree # use git worktree\n  box edit my-feature                          # add/remove repos in a session\n  box list                                     # list all sessions\n  box remove                                   # interactive session removal\n  box remove my-feature                        # remove a session by name\n  box switch my-feature                        # switch to a session\n  box repo add .                               # register current dir as a repo\n  box repo list                                # list registered repos\n  box repo remove my-app                       # unregister a repo\n  box upgrade                                  # self-update"
+    after_help = "Examples:\n  box                                         # interactive session manager\n  box new my-feature --repo app-a              # create a new session\n  box new my-feature --repo app-a --repo app-b # select specific repos\n  box new my-feature --preset work             # create session from preset\n  box new my-feature --repo app --strategy worktree # use git worktree\n  box edit my-feature                          # add/remove repos in a session\n  box list                                     # list all sessions\n  box remove                                   # interactive session removal\n  box remove my-feature                        # remove a session by name\n  box switch my-feature                        # switch to a session\n  box repo add .                               # register current dir as a repo\n  box repo list                                # list registered repos\n  box repo remove my-app                       # unregister a repo\n  box preset add work --repo app-a --repo app-b # define a preset\n  box preset list                               # list presets\n  box preset remove work                        # remove a preset\n  box upgrade                                  # self-update"
 )]
 struct Cli {
     #[command(subcommand)]
@@ -47,6 +48,11 @@ enum Commands {
         #[command(subcommand)]
         action: RepoAction,
     },
+    /// Manage session presets
+    Preset {
+        #[command(subcommand)]
+        action: PresetAction,
+    },
     /// Self-update to the latest version
     Upgrade,
     /// Output shell configuration (e.g. eval "$(box config zsh)")
@@ -74,14 +80,39 @@ enum RepoAction {
     List,
 }
 
+#[derive(Subcommand, Debug)]
+enum PresetAction {
+    /// Create or update a preset
+    Add {
+        /// Preset name
+        name: String,
+        /// Repos to include (can be repeated)
+        #[arg(long, required = true)]
+        repo: Vec<String>,
+    },
+    /// Remove a preset
+    #[command(alias = "rm")]
+    Remove {
+        /// Preset name
+        name: String,
+    },
+    /// List presets
+    #[command(alias = "ls")]
+    List,
+}
+
 #[derive(clap::Args, Debug)]
 struct CreateArgs {
     /// Session name
     name: String,
 
     /// Select specific repos by name (can be repeated)
-    #[arg(long, required = true)]
+    #[arg(long, group = "repo_source")]
     repo: Vec<String>,
+
+    /// Use a preset (mutually exclusive with --repo)
+    #[arg(long, group = "repo_source")]
+    preset: Option<String>,
 
     /// Workspace strategy: worktree (default) or clone
     #[arg(long, env = "BOX_STRATEGY", default_value = "worktree")]
@@ -122,26 +153,7 @@ fn main() {
     let cli = Cli::parse();
 
     let result = match cli.command {
-        Some(Commands::New(args)) => {
-            if std::env::var_os("BOX_SESSION").is_some() {
-                eprintln!(
-                    "Error: cannot nest box sessions (already inside session {:?})",
-                    std::env::var("BOX_SESSION").unwrap_or_default()
-                );
-                std::process::exit(1);
-            }
-            if let Err(e) = update_repos(&args.repo) {
-                eprintln!("Warning: repo update failed: {}", e);
-            }
-            let strategy = match workspace::Strategy::from_str(&args.strategy) {
-                Ok(s) => s,
-                Err(e) => {
-                    eprintln!("Error: {}", e);
-                    std::process::exit(1);
-                }
-            };
-            cmd_create(&args.name, args.repo, strategy)
-        }
+        Some(Commands::New(args)) => cmd_new(args),
         Some(Commands::Edit(args)) => cmd_edit(&args.name),
         Some(Commands::Remove(args)) => match &args.name {
             Some(name) => cmd_remove(name),
@@ -153,6 +165,11 @@ fn main() {
             RepoAction::Add { path } => cmd_repo_add(path),
             RepoAction::Remove { name } => cmd_repo_remove(&name),
             RepoAction::List => cmd_repo_list(),
+        },
+        Some(Commands::Preset { action }) => match action {
+            PresetAction::Add { name, repo } => cmd_preset_add(&name, &repo),
+            PresetAction::Remove { name } => cmd_preset_remove(&name),
+            PresetAction::List => cmd_preset_list(),
         },
         Some(Commands::Upgrade) => cmd_upgrade(),
         Some(Commands::Config { shell }) => match shell {
@@ -385,6 +402,27 @@ fn cmd_list_sessions(args: &ListArgs) -> Result<i32> {
     Ok(0)
 }
 
+fn cmd_new(args: CreateArgs) -> Result<i32> {
+    if std::env::var_os("BOX_SESSION").is_some() {
+        bail!(
+            "Cannot nest box sessions (already inside session {:?}).",
+            std::env::var("BOX_SESSION").unwrap_or_default()
+        );
+    }
+    let repo_names = if let Some(preset_name) = &args.preset {
+        preset::resolve(preset_name)?
+    } else if !args.repo.is_empty() {
+        args.repo
+    } else {
+        bail!("Either --repo or --preset is required.");
+    };
+    if let Err(e) = update_repos(&repo_names) {
+        eprintln!("Warning: repo update failed: {}", e);
+    }
+    let strategy = workspace::Strategy::from_str(&args.strategy)?;
+    cmd_create(&args.name, repo_names, strategy)
+}
+
 fn cmd_create(name: &str, repo_names: Vec<String>, strategy: workspace::Strategy) -> Result<i32> {
     let name = session::validate_name(name)?;
     let name = name.as_str();
@@ -595,6 +633,36 @@ fn cmd_repo_list() -> Result<i32> {
     Ok(0)
 }
 
+fn cmd_preset_add(name: &str, repos: &[String]) -> Result<i32> {
+    preset::add(name, repos)?;
+    Ok(0)
+}
+
+fn cmd_preset_remove(name: &str) -> Result<i32> {
+    preset::remove(name)?;
+    Ok(0)
+}
+
+fn cmd_preset_list() -> Result<i32> {
+    let presets = preset::list()?;
+    if presets.is_empty() {
+        println!("No presets defined.");
+        return Ok(0);
+    }
+    let name_w = presets
+        .iter()
+        .map(|(n, _)| n.len())
+        .max()
+        .unwrap_or(0)
+        .max(4);
+
+    println!("\x1b[2m  {:<name_w$}  REPOS\x1b[0m", "NAME");
+    for (name, repos) in &presets {
+        println!("  {:<name_w$}  {}", name, repos.join(", "));
+    }
+    Ok(0)
+}
+
 fn cmd_config_zsh() -> Result<i32> {
     print!(
         r#"__box_sessions() {{
@@ -637,6 +705,20 @@ __box_repos() {{
     fi
 }}
 
+__box_presets() {{
+    local -a presets
+    local __box_root="${{BOX_ROOT:-$HOME/.box}}"
+    if [[ -d "$__box_root/presets" ]]; then
+        for preset in "$__box_root/presets"/*(N.); do
+            local name=${{preset:t}}
+            [[ -n "$name" ]] && presets+=("$name")
+        done
+    fi
+    if (( ${{#presets}} )); then
+        _describe 'preset' presets
+    fi
+}}
+
 _box() {{
     local curcontext="$curcontext" state line
     typeset -A opt_args
@@ -658,6 +740,7 @@ _box() {{
                 'sw:Switch to a session'
                 'cd:Switch to a session'
                 'repo:Manage registered repos'
+                'preset:Manage session presets'
                 'upgrade:Self-update to the latest version'
                 'config:Output shell configuration'
             )
@@ -668,6 +751,7 @@ _box() {{
                 new)
                     _arguments \
                         '*--repo=[Select specific repo]:repo:__box_repos' \
+                        '--preset=[Use a preset]:preset:__box_presets' \
                         '--strategy=[Workspace strategy]:strategy:(clone worktree)' \
                         '1:session name:' \
                         '*:command:'
@@ -703,6 +787,22 @@ _box() {{
                                 _files -/
                                 ;;
                         esac
+                    fi
+                    ;;
+                preset)
+                    if (( CURRENT == 2 )); then
+                        local -a preset_subcmds
+                        preset_subcmds=('add:Create or update a preset' 'remove:Remove a preset' 'rm:Remove a preset' 'list:List presets' 'ls:List presets')
+                        _describe 'preset subcommand' preset_subcmds
+                    elif (( CURRENT == 3 )); then
+                        case $words[2] in
+                            remove|rm)
+                                __box_presets
+                                ;;
+                        esac
+                    elif [[ $words[2] == "add" ]]; then
+                        _arguments \
+                            '*--repo=[Select specific repo]:repo:__box_repos'
                     fi
                     ;;
                 config)
@@ -742,7 +842,7 @@ fn cmd_config_bash() -> Result<i32> {
     local cur prev words cword
     _init_completion || return
 
-    local subcommands="new edit remove rm list switch sw cd repo upgrade config"
+    local subcommands="new edit remove rm list switch sw cd repo preset upgrade config"
     local session_cmds="edit remove rm switch sw cd"
     local __box_root="${{BOX_ROOT:-$HOME/.box}}"
 
@@ -758,7 +858,7 @@ fn cmd_config_bash() -> Result<i32> {
         new)
             case "$cur" in
                 -*)
-                    COMPREPLY=($(compgen -W "--repo --strategy" -- "$cur"))
+                    COMPREPLY=($(compgen -W "--repo --preset --strategy" -- "$cur"))
                     ;;
             esac
             if [[ "$prev" == "--strategy" ]]; then
@@ -802,6 +902,24 @@ fn cmd_config_bash() -> Result<i32> {
                     add)
                         COMPREPLY=($(compgen -d -- "$cur"))
                         ;;
+                        ;;
+                esac
+            fi
+            ;;
+        preset)
+            if [[ $cword -eq 2 ]]; then
+                COMPREPLY=($(compgen -W "add remove rm list ls" -- "$cur"))
+            elif [[ $cword -eq 3 ]]; then
+                case "${{words[2]}}" in
+                    remove|rm)
+                        local presets=""
+                        if [[ -d "$__box_root/presets" ]]; then
+                            for f in "$__box_root/presets"/*; do
+                                [[ -f "$f" ]] || continue
+                                presets+=" $(basename "$f")"
+                            done
+                        fi
+                        COMPREPLY=($(compgen -W "$presets" -- "$cur"))
                         ;;
                 esac
             fi
@@ -1059,8 +1177,33 @@ mod tests {
     }
 
     #[test]
-    fn test_new_requires_repo() {
-        let result = try_parse(&["new", "my-session"]);
+    fn test_new_name_only_parses() {
+        // --repo and --preset are both optional at parse time; runtime enforces at least one
+        let cli = parse(&["new", "my-session"]);
+        match cli.command {
+            Some(Commands::New(args)) => {
+                assert!(args.repo.is_empty());
+                assert!(args.preset.is_none());
+            }
+            other => panic!("expected New, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_new_with_preset() {
+        let cli = parse(&["new", "my-session", "--preset", "work"]);
+        match cli.command {
+            Some(Commands::New(args)) => {
+                assert_eq!(args.preset.as_deref(), Some("work"));
+                assert!(args.repo.is_empty());
+            }
+            other => panic!("expected New, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_new_preset_and_repo_conflict() {
+        let result = try_parse(&["new", "my-session", "--preset", "work", "--repo", "app"]);
         assert!(result.is_err());
     }
 
@@ -1339,6 +1482,68 @@ mod tests {
             cli.command,
             Some(Commands::Repo {
                 action: RepoAction::List
+            })
+        ));
+    }
+
+    // -- preset subcommand --
+
+    #[test]
+    fn test_preset_add_parses() {
+        let cli = parse(&[
+            "preset", "add", "work", "--repo", "app-a", "--repo", "app-b",
+        ]);
+        match cli.command {
+            Some(Commands::Preset {
+                action: PresetAction::Add { name, repo },
+            }) => {
+                assert_eq!(name, "work");
+                assert_eq!(repo, vec!["app-a", "app-b"]);
+            }
+            other => panic!("expected Preset Add, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_preset_remove_parses() {
+        let cli = parse(&["preset", "remove", "work"]);
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Preset {
+                action: PresetAction::Remove { name }
+            }) if name == "work"
+        ));
+    }
+
+    #[test]
+    fn test_preset_remove_alias_rm() {
+        let cli = parse(&["preset", "rm", "work"]);
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Preset {
+                action: PresetAction::Remove { name }
+            }) if name == "work"
+        ));
+    }
+
+    #[test]
+    fn test_preset_list_parses() {
+        let cli = parse(&["preset", "list"]);
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Preset {
+                action: PresetAction::List
+            })
+        ));
+    }
+
+    #[test]
+    fn test_preset_list_alias_ls() {
+        let cli = parse(&["preset", "ls"]);
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Preset {
+                action: PresetAction::List
             })
         ));
     }

--- a/src/preset.rs
+++ b/src/preset.rs
@@ -1,0 +1,327 @@
+use anyhow::{bail, Result};
+use std::fs;
+use std::path::PathBuf;
+
+use crate::config;
+use crate::repo;
+
+pub fn presets_dir() -> Result<PathBuf> {
+    Ok(config::box_root()?.join("presets"))
+}
+
+pub fn list() -> Result<Vec<(String, Vec<String>)>> {
+    let dir = presets_dir()?;
+    if !dir.is_dir() {
+        return Ok(Vec::new());
+    }
+    let mut entries = Vec::new();
+    for entry in fs::read_dir(&dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().to_string();
+        if name.is_empty() || name.starts_with('.') {
+            continue;
+        }
+        let content = fs::read_to_string(&path)?;
+        let repos: Vec<String> = content
+            .lines()
+            .filter(|l| !l.is_empty())
+            .map(String::from)
+            .collect();
+        if !repos.is_empty() {
+            entries.push((name, repos));
+        }
+    }
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+    Ok(entries)
+}
+
+pub fn load(name: &str) -> Result<Vec<String>> {
+    validate_name(name)?;
+    let path = presets_dir()?.join(name);
+    if !path.is_file() {
+        bail!("No preset named '{}' found.", name);
+    }
+    let content = fs::read_to_string(&path)?;
+    let repos: Vec<String> = content
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(String::from)
+        .collect();
+    Ok(repos)
+}
+
+pub fn add(name: &str, repos: &[String]) -> Result<()> {
+    validate_name(name)?;
+    if repos.is_empty() {
+        bail!("A preset must contain at least one repo.");
+    }
+
+    // Validate all repos exist
+    let all_repos = repo::list()?;
+    let all_names: Vec<&str> = all_repos.iter().map(|r| r.name.as_str()).collect();
+    for r in repos {
+        if !all_names.contains(&r.as_str()) {
+            bail!("Repo '{}' not found in registry.", r);
+        }
+    }
+
+    let dir = presets_dir()?;
+    fs::create_dir_all(&dir)?;
+
+    let path = dir.join(name);
+    let exists = path.is_file();
+    fs::write(&path, repos.join("\n") + "\n")?;
+
+    if exists {
+        eprintln!(
+            "Preset '\x1b[1m{}\x1b[0m' updated ({}).",
+            name,
+            repos.join(", ")
+        );
+    } else {
+        eprintln!(
+            "Preset '\x1b[1m{}\x1b[0m' saved ({}).",
+            name,
+            repos.join(", ")
+        );
+    }
+    Ok(())
+}
+
+pub fn remove(name: &str) -> Result<()> {
+    validate_name(name)?;
+    let path = presets_dir()?.join(name);
+    if !path.is_file() {
+        bail!("No preset named '{}' found.", name);
+    }
+    fs::remove_file(&path)?;
+    eprintln!("Removed preset '{}'.", name);
+    Ok(())
+}
+
+/// Load a preset and validate that all referenced repos still exist.
+/// Warns on stderr for missing repos and filters them out.
+pub fn resolve(name: &str) -> Result<Vec<String>> {
+    let repos = load(name)?;
+    let all_repos = repo::list()?;
+    let all_names: Vec<&str> = all_repos.iter().map(|r| r.name.as_str()).collect();
+
+    let mut valid = Vec::new();
+    for r in &repos {
+        if all_names.contains(&r.as_str()) {
+            valid.push(r.clone());
+        } else {
+            eprintln!(
+                "Warning: preset '{}' references removed repo '{}', skipping.",
+                name, r
+            );
+        }
+    }
+    if valid.is_empty() {
+        bail!(
+            "Preset '{}' has no valid repos (all referenced repos have been removed).",
+            name
+        );
+    }
+    Ok(valid)
+}
+
+fn validate_name(name: &str) -> Result<()> {
+    if name.is_empty() || name.contains('/') || name.contains('\\') || name == ".." || name == "." {
+        bail!("Invalid preset name '{}'.", name);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_util::ENV_LOCK;
+    use std::path::Path;
+
+    fn with_temp_home<F: FnOnce(&Path)>(f: F) {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let old_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", tmp.path());
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            f(tmp.path());
+        }));
+        match old_home {
+            Some(h) => std::env::set_var("HOME", h),
+            None => std::env::remove_var("HOME"),
+        }
+        if let Err(e) = result {
+            std::panic::resume_unwind(e);
+        }
+    }
+
+    fn make_git_repo(base: &Path, name: &str) -> std::path::PathBuf {
+        let dir = base.join(name);
+        fs::create_dir_all(&dir).unwrap();
+        let dir_str = dir.to_str().unwrap();
+        let status = std::process::Command::new("git")
+            .args(["init", dir_str])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .unwrap();
+        assert!(status.success(), "git init failed");
+        let status = std::process::Command::new("git")
+            .args([
+                "-C",
+                dir_str,
+                "-c",
+                "user.name=test",
+                "-c",
+                "user.email=test@test.com",
+                "commit",
+                "--allow-empty",
+                "-m",
+                "init",
+            ])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .unwrap();
+        assert!(status.success(), "git commit failed");
+        dir
+    }
+
+    #[test]
+    fn test_list_empty() {
+        with_temp_home(|_| {
+            let presets = list().unwrap();
+            assert!(presets.is_empty());
+        });
+    }
+
+    #[test]
+    fn test_add_and_list() {
+        with_temp_home(|home| {
+            let repo = make_git_repo(home, "app-a");
+            repo::add(repo.to_str().unwrap()).unwrap();
+            let repo = make_git_repo(home, "app-b");
+            repo::add(repo.to_str().unwrap()).unwrap();
+
+            add("work", &["app-a".to_string(), "app-b".to_string()]).unwrap();
+
+            let presets = list().unwrap();
+            assert_eq!(presets.len(), 1);
+            assert_eq!(presets[0].0, "work");
+            assert_eq!(presets[0].1, vec!["app-a", "app-b"]);
+        });
+    }
+
+    #[test]
+    fn test_add_validates_repos_exist() {
+        with_temp_home(|_| {
+            let err = add("work", &["nonexistent".to_string()]).unwrap_err();
+            assert!(err.to_string().contains("not found in registry"));
+        });
+    }
+
+    #[test]
+    fn test_add_empty_repos_fails() {
+        with_temp_home(|_| {
+            let err = add("work", &[]).unwrap_err();
+            assert!(err.to_string().contains("at least one repo"));
+        });
+    }
+
+    #[test]
+    fn test_add_overwrites() {
+        with_temp_home(|home| {
+            let repo_a = make_git_repo(home, "app-a");
+            let repo_b = make_git_repo(home, "app-b");
+            repo::add(repo_a.to_str().unwrap()).unwrap();
+            repo::add(repo_b.to_str().unwrap()).unwrap();
+
+            add("work", &["app-a".to_string()]).unwrap();
+            add("work", &["app-b".to_string()]).unwrap();
+
+            let repos = load("work").unwrap();
+            assert_eq!(repos, vec!["app-b"]);
+        });
+    }
+
+    #[test]
+    fn test_remove() {
+        with_temp_home(|home| {
+            let repo = make_git_repo(home, "app-a");
+            repo::add(repo.to_str().unwrap()).unwrap();
+            add("work", &["app-a".to_string()]).unwrap();
+
+            remove("work").unwrap();
+            let presets = list().unwrap();
+            assert!(presets.is_empty());
+        });
+    }
+
+    #[test]
+    fn test_remove_not_found() {
+        with_temp_home(|_| {
+            let err = remove("nonexistent").unwrap_err();
+            assert!(err.to_string().contains("No preset named"));
+        });
+    }
+
+    #[test]
+    fn test_load() {
+        with_temp_home(|home| {
+            let repo = make_git_repo(home, "app-a");
+            repo::add(repo.to_str().unwrap()).unwrap();
+            add("work", &["app-a".to_string()]).unwrap();
+
+            let repos = load("work").unwrap();
+            assert_eq!(repos, vec!["app-a"]);
+        });
+    }
+
+    #[test]
+    fn test_resolve_filters_missing_repos() {
+        with_temp_home(|home| {
+            let repo_a = make_git_repo(home, "app-a");
+            let repo_b = make_git_repo(home, "app-b");
+            repo::add(repo_a.to_str().unwrap()).unwrap();
+            repo::add(repo_b.to_str().unwrap()).unwrap();
+            add("work", &["app-a".to_string(), "app-b".to_string()]).unwrap();
+
+            // Remove one repo
+            repo::remove("app-b").unwrap();
+
+            let repos = resolve("work").unwrap();
+            assert_eq!(repos, vec!["app-a"]);
+        });
+    }
+
+    #[test]
+    fn test_resolve_all_repos_missing_fails() {
+        with_temp_home(|home| {
+            let repo = make_git_repo(home, "app-a");
+            repo::add(repo.to_str().unwrap()).unwrap();
+            add("work", &["app-a".to_string()]).unwrap();
+
+            repo::remove("app-a").unwrap();
+
+            let err = resolve("work").unwrap_err();
+            assert!(err.to_string().contains("no valid repos"));
+        });
+    }
+
+    #[test]
+    fn test_path_traversal_rejected() {
+        with_temp_home(|_| {
+            assert!(add("../evil", &["a".to_string()]).is_err());
+            assert!(add("foo/bar", &["a".to_string()]).is_err());
+            assert!(add(".", &["a".to_string()]).is_err());
+            assert!(add("..", &["a".to_string()]).is_err());
+            assert!(load("../evil").is_err());
+            assert!(remove("../evil").is_err());
+        });
+    }
+}

--- a/src/preset.rs
+++ b/src/preset.rs
@@ -28,6 +28,7 @@ pub fn list() -> Result<Vec<(String, Vec<String>)>> {
         let content = fs::read_to_string(&path)?;
         let repos: Vec<String> = content
             .lines()
+            .map(|l| l.trim())
             .filter(|l| !l.is_empty())
             .map(String::from)
             .collect();
@@ -48,6 +49,7 @@ pub fn load(name: &str) -> Result<Vec<String>> {
     let content = fs::read_to_string(&path)?;
     let repos: Vec<String> = content
         .lines()
+        .map(|l| l.trim())
         .filter(|l| !l.is_empty())
         .map(String::from)
         .collect();

--- a/src/preset.rs
+++ b/src/preset.rs
@@ -60,10 +60,14 @@ pub fn add(name: &str, repos: &[String]) -> Result<()> {
         bail!("A preset must contain at least one repo.");
     }
 
+    // Deduplicate repos while preserving order
+    let mut seen = std::collections::HashSet::new();
+    let repos: Vec<&String> = repos.iter().filter(|r| seen.insert(r.as_str())).collect();
+
     // Validate all repos exist
     let all_repos = repo::list()?;
     let all_names: Vec<&str> = all_repos.iter().map(|r| r.name.as_str()).collect();
-    for r in repos {
+    for r in &repos {
         if !all_names.contains(&r.as_str()) {
             bail!("Repo '{}' not found in registry.", r);
         }
@@ -72,21 +76,22 @@ pub fn add(name: &str, repos: &[String]) -> Result<()> {
     let dir = presets_dir()?;
     fs::create_dir_all(&dir)?;
 
+    let repo_strs: Vec<&str> = repos.iter().map(|r| r.as_str()).collect();
     let path = dir.join(name);
     let exists = path.is_file();
-    fs::write(&path, repos.join("\n") + "\n")?;
+    fs::write(&path, repo_strs.join("\n").to_owned() + "\n")?;
 
     if exists {
         eprintln!(
             "Preset '\x1b[1m{}\x1b[0m' updated ({}).",
             name,
-            repos.join(", ")
+            repo_strs.join(", ")
         );
     } else {
         eprintln!(
             "Preset '\x1b[1m{}\x1b[0m' saved ({}).",
             name,
-            repos.join(", ")
+            repo_strs.join(", ")
         );
     }
     Ok(())
@@ -131,7 +136,7 @@ pub fn resolve(name: &str) -> Result<Vec<String>> {
 }
 
 fn validate_name(name: &str) -> Result<()> {
-    if name.is_empty() || name.contains('/') || name.contains('\\') || name == ".." || name == "." {
+    if name.is_empty() || name.contains('/') || name.contains('\\') || name.starts_with('.') {
         bail!("Invalid preset name '{}'.", name);
     }
     Ok(())
@@ -320,7 +325,9 @@ mod tests {
             assert!(add("foo/bar", &["a".to_string()]).is_err());
             assert!(add(".", &["a".to_string()]).is_err());
             assert!(add("..", &["a".to_string()]).is_err());
+            assert!(add(".hidden", &["a".to_string()]).is_err());
             assert!(load("../evil").is_err());
+            assert!(load(".hidden").is_err());
             assert!(remove("../evil").is_err());
         });
     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -42,7 +42,7 @@ pub fn sessions_dir() -> Result<PathBuf> {
 }
 
 const RESERVED_NAMES: &[&str] = &[
-    "new", "remove", "edit", "update", "upgrade", "path", "config", "list", "ls", "repo",
+    "new", "remove", "edit", "update", "upgrade", "path", "config", "list", "ls", "repo", "preset",
 ];
 
 /// Normalize a session name by replacing any non-alphanumeric character with `-`

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -6,6 +6,7 @@ use ratatui::{TerminalOptions, Viewport};
 use std::io;
 
 use crate::config;
+use crate::preset;
 use crate::repo;
 use crate::session;
 
@@ -68,6 +69,7 @@ pub enum TuiAction {
 
 #[derive(PartialEq)]
 enum Mode {
+    PresetSelect,
     RepoSelect,
     Name,
 }
@@ -183,7 +185,7 @@ fn clear_viewport(
     Ok(())
 }
 
-/// Minimal create-session TUI: prompts for repo selection, name, command.
+/// Minimal create-session TUI: prompts for preset/repo selection, name.
 /// Returns `TuiAction::New` or `TuiAction::Quit`.
 pub fn create_session() -> Result<TuiAction> {
     let all_repos = repo::list()?;
@@ -191,9 +193,19 @@ pub fn create_session() -> Result<TuiAction> {
         anyhow::bail!("No repos registered. Run `box repo add <path>` first.");
     }
 
+    let presets = preset::list().unwrap_or_default();
     let repo_count = all_repos.len();
-    // viewport height: repo list + header line
-    let viewport_height = (repo_count as u16) + 1;
+
+    // Start in PresetSelect if presets exist, otherwise RepoSelect
+    let has_presets = !presets.is_empty();
+    // preset_items = number of presets + 1 for "Custom..."
+    let preset_item_count = presets.len() + 1;
+    let initial_height = if has_presets {
+        (preset_item_count as u16) + 1 // items + header
+    } else {
+        (repo_count as u16) + 1 // repos + header
+    };
+    let mut viewport_height = initial_height;
 
     terminal::enable_raw_mode()?;
     let _guard = TermGuard;
@@ -204,7 +216,11 @@ pub fn create_session() -> Result<TuiAction> {
     let mut terminal = Terminal::with_options(CrosstermBackend::new(io::stderr()), options)?;
 
     let mut input = TextInput::new();
-    let mut mode = Mode::RepoSelect;
+    let mut mode = if has_presets {
+        Mode::PresetSelect
+    } else {
+        Mode::RepoSelect
+    };
     let mut footer_msg = String::new();
 
     // Repo selection state — restore from last session if available
@@ -239,6 +255,35 @@ pub fn create_session() -> Result<TuiAction> {
             }
 
             match &mode {
+                Mode::PresetSelect => {
+                    let mut lines: Vec<Line> = Vec::new();
+                    lines.push(Line::from(Span::styled(
+                        "Select a preset (Enter=confirm):",
+                        Style::default().bold(),
+                    )));
+                    for (i, (name, repos)) in presets.iter().enumerate() {
+                        let label = format!(" {} ({})", name, repos.join(", "));
+                        let style = if i == cursor_pos {
+                            Style::default().reversed()
+                        } else {
+                            Style::default()
+                        };
+                        lines.push(Line::from(Span::styled(label, style)));
+                    }
+                    // "Custom..." entry
+                    let custom_style = if cursor_pos == presets.len() {
+                        Style::default().reversed()
+                    } else {
+                        Style::default()
+                    };
+                    lines.push(Line::from(Span::styled(" Custom...", custom_style)));
+                    for (i, line) in lines.into_iter().enumerate() {
+                        if (i as u16) < area.height {
+                            let row = Rect::new(area.x, area.y + i as u16, area.width, 1);
+                            f.render_widget(line, row);
+                        }
+                    }
+                }
                 Mode::RepoSelect => {
                     let mut lines: Vec<Line> = Vec::new();
                     lines.push(Line::from(Span::styled(
@@ -292,6 +337,65 @@ pub fn create_session() -> Result<TuiAction> {
             }
 
             match mode {
+                Mode::PresetSelect => match key.code {
+                    KeyCode::Up => {
+                        cursor_pos = cursor_pos.saturating_sub(1);
+                    }
+                    KeyCode::Down => {
+                        if cursor_pos + 1 < preset_item_count {
+                            cursor_pos += 1;
+                        }
+                    }
+                    KeyCode::Enter => {
+                        if cursor_pos < presets.len() {
+                            // Selected a preset
+                            let (_, repos) = &presets[cursor_pos];
+                            let all_repo_names: Vec<&str> =
+                                all_repos.iter().map(|r| r.name.as_str()).collect();
+                            selected_repos = repos
+                                .iter()
+                                .filter(|r| all_repo_names.contains(&r.as_str()))
+                                .cloned()
+                                .collect();
+                            if selected_repos.is_empty() {
+                                footer_msg =
+                                    "All repos in this preset have been removed.".to_string();
+                            } else {
+                                save_last_selected_repos(&selected_repos);
+                                // Transition to Name mode
+                                clear_viewport(&mut terminal, viewport_height)?;
+                                drop(terminal);
+                                terminal = Terminal::with_options(
+                                    CrosstermBackend::new(io::stderr()),
+                                    TerminalOptions {
+                                        viewport: Viewport::Inline(1),
+                                    },
+                                )?;
+                                viewport_height = 1;
+                                mode = Mode::Name;
+                            }
+                        } else {
+                            // "Custom..." selected — fall through to RepoSelect
+                            clear_viewport(&mut terminal, viewport_height)?;
+                            drop(terminal);
+                            let new_height = (repo_count as u16) + 1;
+                            terminal = Terminal::with_options(
+                                CrosstermBackend::new(io::stderr()),
+                                TerminalOptions {
+                                    viewport: Viewport::Inline(new_height),
+                                },
+                            )?;
+                            viewport_height = new_height;
+                            cursor_pos = 0;
+                            mode = Mode::RepoSelect;
+                        }
+                    }
+                    KeyCode::Esc => {
+                        clear_viewport(&mut terminal, viewport_height)?;
+                        return Ok(TuiAction::Quit);
+                    }
+                    _ => {}
+                },
                 Mode::RepoSelect => match key.code {
                     KeyCode::Up => {
                         cursor_pos = cursor_pos.saturating_sub(1);
@@ -325,6 +429,7 @@ pub fn create_session() -> Result<TuiAction> {
                                 CrosstermBackend::new(io::stderr()),
                                 options,
                             )?;
+                            viewport_height = 1;
                             mode = Mode::Name;
                         }
                     }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -193,7 +193,7 @@ pub fn create_session() -> Result<TuiAction> {
         anyhow::bail!("No repos registered. Run `box repo add <path>` first.");
     }
 
-    let presets = preset::list().unwrap_or_default();
+    let presets = preset::list()?;
     let repo_count = all_repos.len();
 
     // Start in PresetSelect if presets exist, otherwise RepoSelect


### PR DESCRIPTION
## Summary
- Add `box preset add|remove|list` commands to define reusable named sets of repos (stored as flat files under `~/.box/presets/`)
- Add `--preset` flag to `box new` (mutually exclusive with `--repo`) for quick session creation from a preset
- TUI now shows a preset selection screen before repo selection when presets are defined; "Custom..." falls through to the existing repo picker
- Shell completions (zsh + bash) updated for all new commands and flags
- 19 new tests covering preset module, CLI parsing, and edge cases

## Test plan
- [x] `cargo fmt && cargo clippy` — no warnings
- [x] `cargo test` — 112 tests pass
- [ ] `box preset add work --repo <repo1> --repo <repo2>` — creates preset
- [ ] `box preset list` — shows tabular output
- [ ] `box new test-preset --preset work` — creates session with preset repos
- [ ] `box` (TUI) — preset list appears, selecting one skips to name input, "Custom..." goes to repo selection
- [ ] `box preset remove work` — removes preset
- [ ] `box` (TUI after removing all presets) — starts at repo selection as before

v0.1.11

🤖 Generated with [Claude Code](https://claude.com/claude-code)