### PR TITLE
Add interactive TUI repo selector for preset add

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "box-cli"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "box-cli"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 description = "Sandboxed git workspaces for development"
 license = "MIT"

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
         box = pkgs.rustPlatform.buildRustPackage {
           pname = "box";
-          version = "0.1.11";
+          version = "0.1.12";
 
           src = ./.;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,8 +86,8 @@ enum PresetAction {
     Add {
         /// Preset name
         name: String,
-        /// Repos to include (can be repeated)
-        #[arg(long, required = true)]
+        /// Repos to include (can be repeated; opens interactive selector if omitted)
+        #[arg(long)]
         repo: Vec<String>,
     },
     /// Remove a preset
@@ -634,7 +634,20 @@ fn cmd_repo_list() -> Result<i32> {
 }
 
 fn cmd_preset_add(name: &str, repos: &[String]) -> Result<i32> {
-    preset::add(name, repos)?;
+    if repos.is_empty() {
+        // Interactive repo selection — pre-select existing preset repos if updating
+        let current = preset::load(name).unwrap_or_default();
+        match tui::select_preset_repos(&current)? {
+            tui::TuiAction::Edit { repos } => {
+                preset::add(name, &repos)?;
+            }
+            _ => {
+                return Ok(130);
+            }
+        }
+    } else {
+        preset::add(name, repos)?;
+    }
     Ok(0)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -636,13 +636,17 @@ fn cmd_repo_list() -> Result<i32> {
 fn cmd_preset_add(name: &str, repos: &[String]) -> Result<i32> {
     if repos.is_empty() {
         // Interactive repo selection — pre-select existing preset repos if updating
-        let current = preset::load(name).unwrap_or_default();
+        let current = if preset::presets_dir()?.join(name).is_file() {
+            preset::load(name)?
+        } else {
+            Vec::new()
+        };
         match tui::select_preset_repos(&current)? {
             tui::TuiAction::Edit { repos } => {
                 preset::add(name, &repos)?;
             }
             _ => {
-                return Ok(130);
+                return Ok(0);
             }
         }
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -635,11 +635,12 @@ fn cmd_repo_list() -> Result<i32> {
 
 fn cmd_preset_add(name: &str, repos: &[String]) -> Result<i32> {
     if repos.is_empty() {
-        // Interactive repo selection — pre-select existing preset repos if updating
-        let current = if preset::presets_dir()?.join(name).is_file() {
-            preset::load(name)?
-        } else {
-            Vec::new()
+        // Interactive repo selection — pre-select existing preset repos if updating.
+        // validate_name is called by load(), so path traversal is rejected.
+        let current = match preset::load(name) {
+            Ok(repos) => repos,
+            Err(e) if e.to_string().contains("No preset named") => Vec::new(),
+            Err(e) => return Err(e),
         };
         match tui::select_preset_repos(&current)? {
             tui::TuiAction::Edit { repos } => {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -509,9 +509,9 @@ pub fn create_session() -> Result<TuiAction> {
     }
 }
 
-/// TUI for editing session repos: shows checkbox list of all registered repos
-/// with the session's current repos pre-selected. Returns updated repo list.
-pub fn edit_session(current_repos: &[String]) -> Result<TuiAction> {
+/// Shared checkbox list for selecting repos. Takes a header string and initial
+/// selection state. Returns `TuiAction::Edit { repos }` or `TuiAction::Quit`.
+fn select_repos(header: &str, initial_selected: Vec<bool>) -> Result<TuiAction> {
     let all_repos = repo::list()?;
     if all_repos.is_empty() {
         anyhow::bail!("No repos registered. Run `box repo add <path>` first.");
@@ -529,13 +529,11 @@ pub fn edit_session(current_repos: &[String]) -> Result<TuiAction> {
     let mut terminal = Terminal::with_options(CrosstermBackend::new(io::stderr()), options)?;
 
     let mut footer_msg = String::new();
-    let mut selected: Vec<bool> = all_repos
-        .iter()
-        .map(|r| current_repos.contains(&r.name))
-        .collect();
+    let mut selected = initial_selected;
     let mut cursor_pos: usize = 0;
 
     loop {
+        let header = header.to_string();
         terminal.draw(|f| {
             let area = f.area();
 
@@ -550,7 +548,7 @@ pub fn edit_session(current_repos: &[String]) -> Result<TuiAction> {
 
             let mut lines: Vec<Line> = Vec::new();
             lines.push(Line::from(Span::styled(
-                "Edit repos (Space=toggle, Enter=confirm):",
+                header.clone(),
                 Style::default().bold(),
             )));
             for (i, repo) in all_repos.iter().enumerate() {
@@ -630,130 +628,34 @@ pub fn edit_session(current_repos: &[String]) -> Result<TuiAction> {
     }
 }
 
+/// TUI for editing session repos: shows checkbox list of all registered repos
+/// with the session's current repos pre-selected. Returns updated repo list.
+pub fn edit_session(current_repos: &[String]) -> Result<TuiAction> {
+    let all_repos = repo::list()?;
+    let selected = all_repos
+        .iter()
+        .map(|r| current_repos.contains(&r.name))
+        .collect();
+    select_repos("Edit repos (Space=toggle, Enter=confirm):", selected)
+}
+
 /// TUI for selecting repos for a preset: shows checkbox list of all registered repos.
 /// If `current_repos` is non-empty, those repos are pre-selected (for editing an existing preset).
 /// Returns `TuiAction::Edit { repos }` or `TuiAction::Quit`.
 pub fn select_preset_repos(current_repos: &[String]) -> Result<TuiAction> {
     let all_repos = repo::list()?;
-    if all_repos.is_empty() {
-        anyhow::bail!("No repos registered. Run `box repo add <path>` first.");
-    }
-
-    let repo_count = all_repos.len();
-    let viewport_height = (repo_count as u16) + 1;
-
-    terminal::enable_raw_mode()?;
-    let _guard = TermGuard;
-
-    let options = TerminalOptions {
-        viewport: Viewport::Inline(viewport_height),
-    };
-    let mut terminal = Terminal::with_options(CrosstermBackend::new(io::stderr()), options)?;
-
-    let mut footer_msg = String::new();
-    let mut selected: Vec<bool> = if current_repos.is_empty() {
-        vec![false; repo_count]
+    let selected = if current_repos.is_empty() {
+        vec![false; all_repos.len()]
     } else {
         all_repos
             .iter()
             .map(|r| current_repos.contains(&r.name))
             .collect()
     };
-    let mut cursor_pos: usize = 0;
-
-    loop {
-        terminal.draw(|f| {
-            let area = f.area();
-
-            if !footer_msg.is_empty() {
-                let line = Line::from(Span::styled(
-                    footer_msg.as_str(),
-                    Style::default().fg(Color::Red),
-                ));
-                f.render_widget(line, area);
-                return;
-            }
-
-            let mut lines: Vec<Line> = Vec::new();
-            lines.push(Line::from(Span::styled(
-                "Select repos for preset (Space=toggle, Enter=confirm):",
-                Style::default().bold(),
-            )));
-            for (i, repo) in all_repos.iter().enumerate() {
-                let check = if selected[i] { "[x]" } else { "[ ]" };
-                let style = if i == cursor_pos {
-                    Style::default().reversed()
-                } else {
-                    Style::default()
-                };
-                lines.push(Line::from(Span::styled(
-                    format!(" {} {}", check, repo.name),
-                    style,
-                )));
-            }
-            for (i, line) in lines.into_iter().enumerate() {
-                if (i as u16) < area.height {
-                    let row = Rect::new(area.x, area.y + i as u16, area.width, 1);
-                    f.render_widget(line, row);
-                }
-            }
-        })?;
-
-        if !footer_msg.is_empty() {
-            if let Event::Key(key) = event::read()? {
-                if key.kind == KeyEventKind::Press {
-                    footer_msg.clear();
-                }
-            }
-            continue;
-        }
-
-        if let Event::Key(key) = event::read()? {
-            if key.kind != KeyEventKind::Press {
-                continue;
-            }
-
-            if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
-                clear_viewport(&mut terminal, viewport_height)?;
-                return Ok(TuiAction::Quit);
-            }
-
-            match key.code {
-                KeyCode::Up => {
-                    cursor_pos = cursor_pos.saturating_sub(1);
-                }
-                KeyCode::Down => {
-                    if cursor_pos + 1 < repo_count {
-                        cursor_pos += 1;
-                    }
-                }
-                KeyCode::Char(' ') => {
-                    selected[cursor_pos] = !selected[cursor_pos];
-                }
-                KeyCode::Enter => {
-                    let selected_repos: Vec<String> = all_repos
-                        .iter()
-                        .enumerate()
-                        .filter(|(i, _)| selected[*i])
-                        .map(|(_, r)| r.name.clone())
-                        .collect();
-                    if selected_repos.is_empty() {
-                        footer_msg = "At least one repo must be selected.".to_string();
-                    } else {
-                        clear_viewport(&mut terminal, viewport_height)?;
-                        return Ok(TuiAction::Edit {
-                            repos: selected_repos,
-                        });
-                    }
-                }
-                KeyCode::Esc => {
-                    clear_viewport(&mut terminal, viewport_height)?;
-                    return Ok(TuiAction::Quit);
-                }
-                _ => {}
-            }
-        }
-    }
+    select_repos(
+        "Select repos for preset (Space=toggle, Enter=confirm):",
+        selected,
+    )
 }
 
 /// TUI for selecting sessions to remove: shows checkbox list of all sessions.

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -509,10 +509,14 @@ pub fn create_session() -> Result<TuiAction> {
     }
 }
 
-/// Shared checkbox list for selecting repos. Takes a header string and initial
-/// selection state. Returns `TuiAction::Edit { repos }` or `TuiAction::Quit`.
-fn select_repos(header: &str, initial_selected: Vec<bool>) -> Result<TuiAction> {
-    let all_repos = repo::list()?;
+/// Shared checkbox list for selecting repos. Takes the repo list, a header
+/// string, and initial selection state. Returns `TuiAction::Edit { repos }`
+/// or `TuiAction::Quit`.
+fn select_repos(
+    all_repos: Vec<repo::RepoEntry>,
+    header: &str,
+    initial_selected: Vec<bool>,
+) -> Result<TuiAction> {
     if all_repos.is_empty() {
         anyhow::bail!("No repos registered. Run `box repo add <path>` first.");
     }
@@ -531,9 +535,9 @@ fn select_repos(header: &str, initial_selected: Vec<bool>) -> Result<TuiAction> 
     let mut footer_msg = String::new();
     let mut selected = initial_selected;
     let mut cursor_pos: usize = 0;
+    let header = header.to_string();
 
     loop {
-        let header = header.to_string();
         terminal.draw(|f| {
             let area = f.area();
 
@@ -636,7 +640,11 @@ pub fn edit_session(current_repos: &[String]) -> Result<TuiAction> {
         .iter()
         .map(|r| current_repos.contains(&r.name))
         .collect();
-    select_repos("Edit repos (Space=toggle, Enter=confirm):", selected)
+    select_repos(
+        all_repos,
+        "Edit repos (Space=toggle, Enter=confirm):",
+        selected,
+    )
 }
 
 /// TUI for selecting repos for a preset: shows checkbox list of all registered repos.
@@ -653,6 +661,7 @@ pub fn select_preset_repos(current_repos: &[String]) -> Result<TuiAction> {
             .collect()
     };
     select_repos(
+        all_repos,
         "Select repos for preset (Space=toggle, Enter=confirm):",
         selected,
     )

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -630,6 +630,132 @@ pub fn edit_session(current_repos: &[String]) -> Result<TuiAction> {
     }
 }
 
+/// TUI for selecting repos for a preset: shows checkbox list of all registered repos.
+/// If `current_repos` is non-empty, those repos are pre-selected (for editing an existing preset).
+/// Returns `TuiAction::Edit { repos }` or `TuiAction::Quit`.
+pub fn select_preset_repos(current_repos: &[String]) -> Result<TuiAction> {
+    let all_repos = repo::list()?;
+    if all_repos.is_empty() {
+        anyhow::bail!("No repos registered. Run `box repo add <path>` first.");
+    }
+
+    let repo_count = all_repos.len();
+    let viewport_height = (repo_count as u16) + 1;
+
+    terminal::enable_raw_mode()?;
+    let _guard = TermGuard;
+
+    let options = TerminalOptions {
+        viewport: Viewport::Inline(viewport_height),
+    };
+    let mut terminal = Terminal::with_options(CrosstermBackend::new(io::stderr()), options)?;
+
+    let mut footer_msg = String::new();
+    let mut selected: Vec<bool> = if current_repos.is_empty() {
+        vec![false; repo_count]
+    } else {
+        all_repos
+            .iter()
+            .map(|r| current_repos.contains(&r.name))
+            .collect()
+    };
+    let mut cursor_pos: usize = 0;
+
+    loop {
+        terminal.draw(|f| {
+            let area = f.area();
+
+            if !footer_msg.is_empty() {
+                let line = Line::from(Span::styled(
+                    footer_msg.as_str(),
+                    Style::default().fg(Color::Red),
+                ));
+                f.render_widget(line, area);
+                return;
+            }
+
+            let mut lines: Vec<Line> = Vec::new();
+            lines.push(Line::from(Span::styled(
+                "Select repos for preset (Space=toggle, Enter=confirm):",
+                Style::default().bold(),
+            )));
+            for (i, repo) in all_repos.iter().enumerate() {
+                let check = if selected[i] { "[x]" } else { "[ ]" };
+                let style = if i == cursor_pos {
+                    Style::default().reversed()
+                } else {
+                    Style::default()
+                };
+                lines.push(Line::from(Span::styled(
+                    format!(" {} {}", check, repo.name),
+                    style,
+                )));
+            }
+            for (i, line) in lines.into_iter().enumerate() {
+                if (i as u16) < area.height {
+                    let row = Rect::new(area.x, area.y + i as u16, area.width, 1);
+                    f.render_widget(line, row);
+                }
+            }
+        })?;
+
+        if !footer_msg.is_empty() {
+            if let Event::Key(key) = event::read()? {
+                if key.kind == KeyEventKind::Press {
+                    footer_msg.clear();
+                }
+            }
+            continue;
+        }
+
+        if let Event::Key(key) = event::read()? {
+            if key.kind != KeyEventKind::Press {
+                continue;
+            }
+
+            if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
+                clear_viewport(&mut terminal, viewport_height)?;
+                return Ok(TuiAction::Quit);
+            }
+
+            match key.code {
+                KeyCode::Up => {
+                    cursor_pos = cursor_pos.saturating_sub(1);
+                }
+                KeyCode::Down => {
+                    if cursor_pos + 1 < repo_count {
+                        cursor_pos += 1;
+                    }
+                }
+                KeyCode::Char(' ') => {
+                    selected[cursor_pos] = !selected[cursor_pos];
+                }
+                KeyCode::Enter => {
+                    let selected_repos: Vec<String> = all_repos
+                        .iter()
+                        .enumerate()
+                        .filter(|(i, _)| selected[*i])
+                        .map(|(_, r)| r.name.clone())
+                        .collect();
+                    if selected_repos.is_empty() {
+                        footer_msg = "At least one repo must be selected.".to_string();
+                    } else {
+                        clear_viewport(&mut terminal, viewport_height)?;
+                        return Ok(TuiAction::Edit {
+                            repos: selected_repos,
+                        });
+                    }
+                }
+                KeyCode::Esc => {
+                    clear_viewport(&mut terminal, viewport_height)?;
+                    return Ok(TuiAction::Quit);
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
 /// TUI for selecting sessions to remove: shows checkbox list of all sessions.
 /// Returns `TuiAction::Remove { sessions }` or `TuiAction::Quit`.
 pub fn select_sessions() -> Result<TuiAction> {


### PR DESCRIPTION
## Summary
- `box preset add <name>` without `--repo` flags now opens an interactive checkbox TUI to select repos
- When updating an existing preset, its current repos are pre-selected
- `--repo` flag path continues to work as before for scripting

## Test plan
- [ ] Run `box preset add work` without `--repo` — verify TUI opens with all repos unchecked
- [ ] Run `box preset add work` when `work` already exists — verify current repos are pre-checked
- [ ] Run `box preset add work --repo app-a` — verify it still works without TUI
- [ ] Press Esc/Ctrl-C in TUI — verify clean exit with no preset saved
- [ ] Select no repos and press Enter — verify error message appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)