### PR TITLE
Parallelize session and worktree removal for faster box rm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "box-cli"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "box-cli"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2021"
 description = "Sandboxed git workspaces for development"
 license = "MIT"

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
         box = pkgs.rustPlatform.buildRustPackage {
           pname = "box";
-          version = "0.1.15";
+          version = "0.1.16";
 
           src = ./.;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -561,28 +561,16 @@ fn cmd_remove(name: &str) -> Result<i32> {
 fn cmd_remove_tui() -> Result<i32> {
     match tui::select_sessions()? {
         tui::TuiAction::Remove { sessions } => {
-            // Pre-load session data before parallel removal
-            let items: Vec<(String, Option<session::Session>)> = sessions
-                .iter()
-                .map(|name| (name.clone(), session::load(name).ok()))
-                .collect();
-
-            let results = parallel::run_parallel(items, |name, sess_opt| {
-                if let Some(sess) = sess_opt {
+            for name in &sessions {
+                if let Ok(sess) = session::load(name) {
                     let strategy = workspace::Strategy::from_str(&sess.strategy)
                         .unwrap_or(workspace::Strategy::Clone);
                     workspace::remove_workspace_by_strategy(name, &sess.repos, strategy);
                 } else {
                     workspace::remove_workspace(name);
                 }
-                match session::remove_dir(name) {
-                    Ok(()) => (true, format!("Session '{}' removed.", name)),
-                    Err(e) => (false, format!("Failed to remove '{}': {}", name, e)),
-                }
-            });
-
-            for result in &results {
-                eprintln!("{}", result.output);
+                session::remove_dir(name)?;
+                eprintln!("Session '{}' removed.", name);
             }
             Ok(0)
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -561,16 +561,28 @@ fn cmd_remove(name: &str) -> Result<i32> {
 fn cmd_remove_tui() -> Result<i32> {
     match tui::select_sessions()? {
         tui::TuiAction::Remove { sessions } => {
-            for name in &sessions {
-                if let Ok(sess) = session::load(name) {
+            // Pre-load session data before parallel removal
+            let items: Vec<(String, Option<session::Session>)> = sessions
+                .iter()
+                .map(|name| (name.clone(), session::load(name).ok()))
+                .collect();
+
+            let results = parallel::run_parallel(items, |name, sess_opt| {
+                if let Some(sess) = sess_opt {
                     let strategy = workspace::Strategy::from_str(&sess.strategy)
                         .unwrap_or(workspace::Strategy::Clone);
                     workspace::remove_workspace_by_strategy(name, &sess.repos, strategy);
                 } else {
                     workspace::remove_workspace(name);
                 }
-                session::remove_dir(name)?;
-                eprintln!("Session '{}' removed.", name);
+                match session::remove_dir(name) {
+                    Ok(()) => (true, format!("Session '{}' removed.", name)),
+                    Err(e) => (false, format!("Failed to remove '{}': {}", name, e)),
+                }
+            });
+
+            for result in &results {
+                eprintln!("{}", result.output);
             }
             Ok(0)
         }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Result};
 use std::fmt;
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use crate::config;
 
@@ -225,34 +225,41 @@ pub fn remove_workspace_worktree(name: &str, repo_names: &[String]) {
         .iter()
         .map(|repo_name| {
             let dest = root.join("workspaces").join(name).join(repo_name);
-            let dest_str = dest.to_string_lossy().to_string();
             let repo_path = all_repos
                 .iter()
                 .find(|r| r.name == *repo_name)
                 .map(|r| r.path.clone());
-            (
-                repo_name.clone(),
-                (repo_path, dest_str, branch_name.clone()),
-            )
+            (repo_name.clone(), (repo_path, dest, branch_name.clone()))
         })
         .collect();
 
     if !items.is_empty() {
-        crate::parallel::run_parallel(items, |_name, (repo_path, dest_str, branch)| {
+        crate::parallel::run_parallel(items, |_name, (repo_path, dest, branch)| {
             if let Some(path) = repo_path {
+                let dest_str = dest.to_string_lossy().to_string();
                 // Remove worktree via git
                 let _ = Command::new("git")
                     .args(["-C", &path, "worktree", "remove", "--force", &dest_str])
-                    .output();
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .status();
                 // Delete the branch
                 let _ = Command::new("git")
                     .args(["-C", &path, "branch", "-D", &branch])
-                    .output();
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .status();
+                (true, String::new())
             } else {
                 // Repo not in registry, fall back to rm -rf
-                let _ = std::fs::remove_dir_all(&dest_str);
+                match std::fs::remove_dir_all(&dest) {
+                    Ok(()) => (true, String::new()),
+                    Err(e) => (
+                        false,
+                        format!("failed to remove '{}': {}", dest.display(), e),
+                    ),
+                }
             }
-            (true, String::new())
         });
     }
 

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -212,6 +212,7 @@ pub fn remove_repo_from_workspace(session_name: &str, repo_name: &str) {
 
 /// Remove worktrees for a session. For each repo, removes the worktree and
 /// deletes the branch. Falls back to rm -rf if repo not in registry.
+/// Repos are removed in parallel for speed.
 pub fn remove_workspace_worktree(name: &str, repo_names: &[String]) {
     let all_repos = crate::repo::list().unwrap_or_default();
     let root = match config::box_root() {
@@ -220,30 +221,39 @@ pub fn remove_workspace_worktree(name: &str, repo_names: &[String]) {
     };
     let branch_name = format!("box/{}", name);
 
-    for repo_name in repo_names {
-        let dest = root.join("workspaces").join(name).join(repo_name);
-        let dest_str = dest.to_string_lossy().to_string();
+    let items: Vec<_> = repo_names
+        .iter()
+        .map(|repo_name| {
+            let dest = root.join("workspaces").join(name).join(repo_name);
+            let dest_str = dest.to_string_lossy().to_string();
+            let repo_path = all_repos
+                .iter()
+                .find(|r| r.name == *repo_name)
+                .map(|r| r.path.clone());
+            (
+                repo_name.clone(),
+                (repo_path, dest_str, branch_name.clone()),
+            )
+        })
+        .collect();
 
-        if let Some(entry) = all_repos.iter().find(|r| r.name == *repo_name) {
-            // Remove worktree via git
-            let _ = Command::new("git")
-                .args([
-                    "-C",
-                    &entry.path,
-                    "worktree",
-                    "remove",
-                    "--force",
-                    &dest_str,
-                ])
-                .status();
-            // Delete the branch
-            let _ = Command::new("git")
-                .args(["-C", &entry.path, "branch", "-D", &branch_name])
-                .status();
-        } else {
-            // Repo not in registry, fall back to rm -rf
-            let _ = std::fs::remove_dir_all(&dest);
-        }
+    if !items.is_empty() {
+        crate::parallel::run_parallel(items, |_name, (repo_path, dest_str, branch)| {
+            if let Some(path) = repo_path {
+                // Remove worktree via git
+                let _ = Command::new("git")
+                    .args(["-C", &path, "worktree", "remove", "--force", &dest_str])
+                    .output();
+                // Delete the branch
+                let _ = Command::new("git")
+                    .args(["-C", &path, "branch", "-D", &branch])
+                    .output();
+            } else {
+                // Repo not in registry, fall back to rm -rf
+                let _ = std::fs::remove_dir_all(&dest_str);
+            }
+            (true, String::new())
+        });
     }
 
     // Remove session workspace root dir


### PR DESCRIPTION
## Summary
- Parallelize per-repo worktree removal in `remove_workspace_worktree` using `run_parallel`, so `git worktree remove` + `git branch -D` run concurrently across repos
- Parallelize per-session removal in `cmd_remove_tui`, so removing multiple sessions from the TUI selector happens concurrently
- Bump version to v0.1.16

## Test plan
- [x] `cargo test` — all 116 tests pass
- [x] `cargo clippy` — no warnings
- [ ] `box rm` with a single multi-repo worktree session — verify all repos cleaned up
- [ ] `box rm` (TUI) selecting multiple sessions — verify all removed in parallel

🤖 Generated with [Claude Code](https://claude.com/claude-code)