### PR TITLE
Add compact output with --verbose flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "box-cli"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "box-cli"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2021"
 description = "Sandboxed git workspaces for development"
 license = "MIT"

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
         box = pkgs.rustPlatform.buildRustPackage {
           pname = "box";
-          version = "0.1.16";
+          version = "0.1.17";
 
           src = ./.;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -804,11 +804,16 @@ _box() {{
                         '-q[Only print session names]'
                     ;;
                 remove|rm)
-                    if (( CURRENT == 2 )); then
-                        __box_sessions
-                    fi
+                    _arguments \
+                        '(-v --verbose)'{{-v,--verbose}}'[Show detailed output]' \
+                        '1:session name:__box_sessions'
                     ;;
-                edit|switch|sw|cd)
+                edit)
+                    _arguments \
+                        '(-v --verbose)'{{-v,--verbose}}'[Show detailed output]' \
+                        '1:session name:__box_sessions'
+                    ;;
+                switch|sw|cd)
                     if (( CURRENT == 2 )); then
                         __box_sessions
                     fi
@@ -922,7 +927,25 @@ fn cmd_config_bash() -> Result<i32> {
                     ;;
             esac
             ;;
-        edit|remove|rm|switch|sw|cd)
+        edit|remove|rm)
+            case "$cur" in
+                -*)
+                    COMPREPLY=($(compgen -W "--verbose -v" -- "$cur"))
+                    ;;
+                *)
+                    if [[ $cword -eq 2 ]]; then
+                        local sessions=""
+                        if [[ -d "$__box_root/sessions" ]]; then
+                            for sess in "$__box_root/sessions"/*/; do
+                                ([[ -f "$sess/project_dir" ]] || [[ -f "$sess/repos" ]]) && sessions+=" $(basename "$sess")"
+                            done
+                        fi
+                        COMPREPLY=($(compgen -W "$sessions" -- "$cur"))
+                    fi
+                    ;;
+            esac
+            ;;
+        switch|sw|cd)
             if [[ $cword -eq 2 ]]; then
                 local sessions=""
                 if [[ -d "$__box_root/sessions" ]]; then

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,8 +168,8 @@ fn main() {
         Some(Commands::New(args)) => cmd_new(args, verbose),
         Some(Commands::Edit(args)) => cmd_edit(&args.name, verbose),
         Some(Commands::Remove(args)) => match &args.name {
-            Some(name) => cmd_remove(name),
-            None => cmd_remove_tui(),
+            Some(name) => cmd_remove(name, verbose),
+            None => cmd_remove_tui(verbose),
         },
         Some(Commands::List(args)) => cmd_list_sessions(&args),
         Some(Commands::Switch { name }) => cmd_cd(&name),
@@ -549,7 +549,7 @@ fn cmd_edit(name: &str, verbose: bool) -> Result<i32> {
     }
 }
 
-fn cmd_remove(name: &str) -> Result<i32> {
+fn cmd_remove(name: &str, verbose: bool) -> Result<i32> {
     let name = session::validate_name(name)?;
     let name = name.as_str();
 
@@ -561,7 +561,7 @@ fn cmd_remove(name: &str) -> Result<i32> {
     let strategy =
         workspace::Strategy::from_str(&sess.strategy).unwrap_or(workspace::Strategy::Clone);
 
-    workspace::remove_workspace_by_strategy(name, &sess.repos, strategy);
+    workspace::remove_workspace_by_strategy(name, &sess.repos, strategy, verbose);
     session::remove_dir(name)?;
 
     if !sess.project_dir.is_empty() {
@@ -571,14 +571,14 @@ fn cmd_remove(name: &str) -> Result<i32> {
     Ok(0)
 }
 
-fn cmd_remove_tui() -> Result<i32> {
+fn cmd_remove_tui(verbose: bool) -> Result<i32> {
     match tui::select_sessions()? {
         tui::TuiAction::Remove { sessions } => {
             for name in &sessions {
                 if let Ok(sess) = session::load(name) {
                     let strategy = workspace::Strategy::from_str(&sess.strategy)
                         .unwrap_or(workspace::Strategy::Clone);
-                    workspace::remove_workspace_by_strategy(name, &sess.repos, strategy);
+                    workspace::remove_workspace_by_strategy(name, &sess.repos, strategy, verbose);
                 } else {
                     workspace::remove_workspace(name);
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -465,12 +465,19 @@ fn cmd_create(
         repos: repo_names_list,
     })?;
 
-    eprintln!(
-        "\x1b[2msession:\x1b[0m {} \x1b[2m({} repos, {})\x1b[0m",
-        name,
-        cfg.repos.len(),
-        strategy
-    );
+    if verbose {
+        eprintln!("\x1b[2msession:\x1b[0m {}", name);
+        eprintln!("\x1b[2mrepos:\x1b[0m {}", cfg.repos.join(", "));
+        eprintln!("\x1b[2mstrategy:\x1b[0m {}", strategy);
+        eprintln!();
+    } else {
+        eprintln!(
+            "\x1b[2msession:\x1b[0m {} \x1b[2m({} repos, {})\x1b[0m",
+            name,
+            cfg.repos.len(),
+            strategy
+        );
+    }
 
     let mut sess = session::Session::from(cfg);
     sess.strategy = strategy.as_str().to_string();

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,10 @@ use std::path::{Path, PathBuf};
     after_help = "Examples:\n  box                                         # interactive session manager\n  box new my-feature --repo app-a              # create a new session\n  box new my-feature --repo app-a --repo app-b # select specific repos\n  box new my-feature --preset work             # create session from preset\n  box new my-feature --repo app --strategy worktree # use git worktree\n  box edit my-feature                          # add/remove repos in a session\n  box list                                     # list all sessions\n  box remove                                   # interactive session removal\n  box remove my-feature                        # remove a session by name\n  box switch my-feature                        # switch to a session\n  box repo add .                               # register current dir as a repo\n  box repo list                                # list registered repos\n  box repo remove my-app                       # unregister a repo\n  box preset add work --repo app-a --repo app-b # define a preset\n  box preset edit work                          # edit repos in a preset\n  box preset list                               # list presets\n  box preset remove work                        # remove a preset\n  box upgrade                                  # self-update"
 )]
 struct Cli {
+    /// Show detailed output
+    #[arg(long, short = 'v', global = true, env = "BOX_VERBOSE")]
+    verbose: bool,
+
     #[command(subcommand)]
     command: Option<Commands>,
 }
@@ -158,9 +162,11 @@ enum ConfigShell {
 fn main() {
     let cli = Cli::parse();
 
+    let verbose = cli.verbose;
+
     let result = match cli.command {
-        Some(Commands::New(args)) => cmd_new(args),
-        Some(Commands::Edit(args)) => cmd_edit(&args.name),
+        Some(Commands::New(args)) => cmd_new(args, verbose),
+        Some(Commands::Edit(args)) => cmd_edit(&args.name, verbose),
         Some(Commands::Remove(args)) => match &args.name {
             Some(name) => cmd_remove(name),
             None => cmd_remove_tui(),
@@ -183,7 +189,7 @@ fn main() {
             ConfigShell::Zsh => cmd_config_zsh(),
             ConfigShell::Bash => cmd_config_bash(),
         },
-        None => cmd_default(),
+        None => cmd_default(verbose),
     };
 
     match result {
@@ -298,25 +304,25 @@ fn resolve_project_dir(
 }
 
 /// `box` with no args: interactive TUI to create a session.
-fn cmd_default() -> Result<i32> {
+fn cmd_default(verbose: bool) -> Result<i32> {
     if std::env::var_os("BOX_SESSION").is_some() {
         bail!(
             "Cannot nest box sessions (already inside session {:?}).",
             std::env::var("BOX_SESSION").unwrap_or_default()
         );
     }
-    cmd_create_tui()
+    cmd_create_tui(verbose)
 }
 
 /// `box create` with no name: prompt for session details.
-fn cmd_create_tui() -> Result<i32> {
+fn cmd_create_tui(verbose: bool) -> Result<i32> {
     let strategy = workspace::Strategy::resolve(None)?;
     match tui::create_session()? {
         tui::TuiAction::New { name, repos } => {
-            if let Err(e) = update_repos(&repos) {
+            if let Err(e) = update_repos(&repos, verbose) {
                 eprintln!("Warning: repo update failed: {}", e);
             }
-            cmd_create(&name, repos, strategy)
+            cmd_create(&name, repos, strategy, verbose)
         }
         _ => Ok(0),
     }
@@ -397,7 +403,7 @@ fn cmd_list_sessions(args: &ListArgs) -> Result<i32> {
     Ok(0)
 }
 
-fn cmd_new(args: CreateArgs) -> Result<i32> {
+fn cmd_new(args: CreateArgs, verbose: bool) -> Result<i32> {
     if std::env::var_os("BOX_SESSION").is_some() {
         bail!(
             "Cannot nest box sessions (already inside session {:?}).",
@@ -411,14 +417,19 @@ fn cmd_new(args: CreateArgs) -> Result<i32> {
     } else {
         bail!("Either --repo or --preset is required.");
     };
-    if let Err(e) = update_repos(&repo_names) {
+    if let Err(e) = update_repos(&repo_names, verbose) {
         eprintln!("Warning: repo update failed: {}", e);
     }
     let strategy = workspace::Strategy::from_str(&args.strategy)?;
-    cmd_create(&args.name, repo_names, strategy)
+    cmd_create(&args.name, repo_names, strategy, verbose)
 }
 
-fn cmd_create(name: &str, repo_names: Vec<String>, strategy: workspace::Strategy) -> Result<i32> {
+fn cmd_create(
+    name: &str,
+    repo_names: Vec<String>,
+    strategy: workspace::Strategy,
+    verbose: bool,
+) -> Result<i32> {
     let name = session::validate_name(name)?;
     let name = name.as_str();
 
@@ -454,16 +465,18 @@ fn cmd_create(name: &str, repo_names: Vec<String>, strategy: workspace::Strategy
         repos: repo_names_list,
     })?;
 
-    eprintln!("\x1b[2msession:\x1b[0m {}", name);
-    eprintln!("\x1b[2mrepos:\x1b[0m {}", cfg.repos.join(", "));
-    eprintln!("\x1b[2mstrategy:\x1b[0m {}", strategy);
-    eprintln!();
+    eprintln!(
+        "\x1b[2msession:\x1b[0m {} \x1b[2m({} repos, {})\x1b[0m",
+        name,
+        cfg.repos.len(),
+        strategy
+    );
 
     let mut sess = session::Session::from(cfg);
     sess.strategy = strategy.as_str().to_string();
     session::save(&sess)?;
 
-    let workspace_path = workspace::ensure_workspace(name, &selected_repos, strategy)?;
+    let workspace_path = workspace::ensure_workspace(name, &selected_repos, strategy, verbose)?;
     if selected_repos.len() == 1 {
         let repo_path = Path::new(&workspace_path).join(&selected_repos[0].name);
         output_cd_path(&repo_path.to_string_lossy());
@@ -475,7 +488,7 @@ fn cmd_create(name: &str, repo_names: Vec<String>, strategy: workspace::Strategy
     Ok(0)
 }
 
-fn cmd_edit(name: &str) -> Result<i32> {
+fn cmd_edit(name: &str, verbose: bool) -> Result<i32> {
     let name = session::validate_name(name)?;
     let name = name.as_str();
 
@@ -509,7 +522,7 @@ fn cmd_edit(name: &str) -> Result<i32> {
                     .iter()
                     .filter_map(|name| all_repos.iter().find(|r| r.name == *name).cloned())
                     .collect();
-                workspace::ensure_workspace(name, &repos_to_add, strategy)?;
+                workspace::ensure_workspace(name, &repos_to_add, strategy, verbose)?;
             }
 
             // Remove workspace directories for removed repos
@@ -779,6 +792,7 @@ _box() {{
                         '*--repo=[Select specific repo]:repo:__box_repos' \
                         '--preset=[Use a preset]:preset:__box_presets' \
                         '--strategy=[Workspace strategy]:strategy:(clone worktree)' \
+                        '(-v --verbose)'{{-v,--verbose}}'[Show detailed output]' \
                         '1:session name:' \
                         '*:command:'
                     ;;
@@ -894,7 +908,7 @@ fn cmd_config_bash() -> Result<i32> {
         new)
             case "$cur" in
                 -*)
-                    COMPREPLY=($(compgen -W "--repo --preset --strategy" -- "$cur"))
+                    COMPREPLY=($(compgen -W "--repo --preset --strategy --verbose -v" -- "$cur"))
                     ;;
             esac
             if [[ "$prev" == "--strategy" ]]; then
@@ -1066,7 +1080,7 @@ fn worktree_checked_out_branches(bare_path: &str) -> Vec<String> {
 }
 
 /// Fetch named repos in parallel.
-fn update_repos(names: &[String]) -> Result<()> {
+fn update_repos(names: &[String], verbose: bool) -> Result<()> {
     let all_repos = repo::list()?;
     let items: Vec<(String, repo::RepoEntry)> = all_repos
         .into_iter()
@@ -1077,16 +1091,37 @@ fn update_repos(names: &[String]) -> Result<()> {
         return Ok(());
     }
 
-    eprintln!("\x1b[2mUpdating repos…\x1b[0m");
+    let count = items.len();
+    if verbose {
+        eprintln!("\x1b[2mUpdating repos…\x1b[0m");
+    } else {
+        eprint!(
+            "\x1b[2mFetching {} repo{}…\x1b[0m ",
+            count,
+            if count == 1 { "" } else { "s" }
+        );
+    }
     let results = parallel::run_parallel(items, |_name, entry| update_repo_captured(&entry));
 
-    for result in &results {
-        eprintln!("\x1b[1m{}\x1b[0m", result.name);
-        if !result.output.is_empty() {
-            eprint!("{}", result.output);
+    if verbose {
+        for result in &results {
+            eprintln!("\x1b[1m{}\x1b[0m", result.name);
+            if !result.output.is_empty() {
+                eprint!("{}", result.output);
+            }
+            if result.success {
+                eprintln!("  \x1b[32mok\x1b[0m");
+            }
         }
-        if result.success {
-            eprintln!("  \x1b[32mok\x1b[0m");
+    } else {
+        let failures: Vec<&parallel::TaskResult> = results.iter().filter(|r| !r.success).collect();
+        if failures.is_empty() {
+            eprintln!("\x1b[32mok\x1b[0m");
+        } else {
+            eprintln!("\x1b[31m{} failed\x1b[0m", failures.len());
+            for f in &failures {
+                eprintln!("  \x1b[1m{}\x1b[0m: {}", f.name, f.output.trim());
+            }
         }
     }
 

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -55,6 +55,7 @@ pub fn remove_workspace(name: &str) {
 pub fn ensure_workspace_multi(
     session_name: &str,
     repos: &[crate::repo::RepoEntry],
+    verbose: bool,
 ) -> Result<String> {
     let root = config::box_root()?.join("workspaces").join(session_name);
     std::fs::create_dir_all(&root)?;
@@ -100,13 +101,21 @@ pub fn ensure_workspace_multi(
         });
 
         let mut failures = Vec::new();
-        for result in &results {
-            eprintln!("\x1b[2mcloning {}:\x1b[0m", result.name);
-            if !result.output.is_empty() {
-                eprint!("{}", result.output);
+        if verbose {
+            for result in &results {
+                eprintln!("\x1b[2mcloning {}:\x1b[0m", result.name);
+                if !result.output.is_empty() {
+                    eprint!("{}", result.output);
+                }
+                if !result.success {
+                    failures.push(result.name.clone());
+                }
             }
-            if !result.success {
-                failures.push(result.name.clone());
+        } else {
+            for result in &results {
+                if !result.success {
+                    failures.push(result.name.clone());
+                }
             }
         }
         if !failures.is_empty() {
@@ -121,6 +130,7 @@ pub fn ensure_workspace_multi(
 pub fn ensure_workspace_multi_worktree(
     session_name: &str,
     repos: &[crate::repo::RepoEntry],
+    verbose: bool,
 ) -> Result<String> {
     let root = config::box_root()?.join("workspaces").join(session_name);
     std::fs::create_dir_all(&root)?;
@@ -185,13 +195,21 @@ pub fn ensure_workspace_multi_worktree(
             });
 
         let mut failures = Vec::new();
-        for result in &results {
-            eprintln!("\x1b[2mworktree {}:\x1b[0m", result.name);
-            if !result.output.is_empty() {
-                eprint!("{}", result.output);
+        if verbose {
+            for result in &results {
+                eprintln!("\x1b[2mworktree {}:\x1b[0m", result.name);
+                if !result.output.is_empty() {
+                    eprint!("{}", result.output);
+                }
+                if !result.success {
+                    failures.push(result.name.clone());
+                }
             }
-            if !result.success {
-                failures.push(result.name.clone());
+        } else {
+            for result in &results {
+                if !result.success {
+                    failures.push(result.name.clone());
+                }
             }
         }
         if !failures.is_empty() {
@@ -305,11 +323,32 @@ pub fn ensure_workspace(
     name: &str,
     repos: &[crate::repo::RepoEntry],
     strategy: Strategy,
+    verbose: bool,
 ) -> Result<String> {
-    match strategy {
-        Strategy::Clone => ensure_workspace_multi(name, repos),
-        Strategy::Worktree => ensure_workspace_multi_worktree(name, repos),
+    let count = repos.len();
+    let label = match strategy {
+        Strategy::Clone => "Cloning",
+        Strategy::Worktree => "Creating worktrees",
+    };
+    if !verbose {
+        eprint!(
+            "\x1b[2m{} for {} repo{}…\x1b[0m ",
+            label,
+            count,
+            if count == 1 { "" } else { "s" }
+        );
     }
+    let result = match strategy {
+        Strategy::Clone => ensure_workspace_multi(name, repos, verbose),
+        Strategy::Worktree => ensure_workspace_multi_worktree(name, repos, verbose),
+    };
+    if !verbose {
+        match &result {
+            Ok(_) => eprintln!("\x1b[32mok\x1b[0m"),
+            Err(_) => eprintln!("\x1b[31mfailed\x1b[0m"),
+        }
+    }
+    result
 }
 
 /// Remove workspace using the given strategy.

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Result};
 use std::fmt;
-use std::process::{Command, Stdio};
+use std::process::Command;
 
 use crate::config;
 
@@ -231,7 +231,7 @@ pub fn remove_repo_from_workspace(session_name: &str, repo_name: &str) {
 /// Remove worktrees for a session. For each repo, removes the worktree and
 /// deletes the branch. Falls back to rm -rf if repo not in registry.
 /// Repos are removed in parallel for speed.
-pub fn remove_workspace_worktree(name: &str, repo_names: &[String]) {
+pub fn remove_workspace_worktree(name: &str, repo_names: &[String], verbose: bool) {
     let all_repos = crate::repo::list().unwrap_or_default();
     let root = match config::box_root() {
         Ok(r) => r,
@@ -252,22 +252,33 @@ pub fn remove_workspace_worktree(name: &str, repo_names: &[String]) {
         .collect();
 
     if !items.is_empty() {
-        crate::parallel::run_parallel(items, |_name, (repo_path, dest, branch)| {
+        let count = items.len();
+        if !verbose {
+            eprint!(
+                "\x1b[2mRemoving {} worktree{}…\x1b[0m ",
+                count,
+                if count == 1 { "" } else { "s" }
+            );
+        }
+        let results = crate::parallel::run_parallel(items, |_name, (repo_path, dest, branch)| {
             if let Some(path) = repo_path {
                 let dest_str = dest.to_string_lossy().to_string();
                 // Remove worktree via git
-                let _ = Command::new("git")
+                let wt = Command::new("git")
                     .args(["-C", &path, "worktree", "remove", "--force", &dest_str])
-                    .stdout(Stdio::null())
-                    .stderr(Stdio::null())
-                    .status();
+                    .output();
                 // Delete the branch
-                let _ = Command::new("git")
+                let br = Command::new("git")
                     .args(["-C", &path, "branch", "-D", &branch])
-                    .stdout(Stdio::null())
-                    .stderr(Stdio::null())
-                    .status();
-                (true, String::new())
+                    .output();
+                let mut buf = String::new();
+                if let Ok(o) = wt {
+                    buf.push_str(&captured_output(&o));
+                }
+                if let Ok(o) = br {
+                    buf.push_str(&captured_output(&o));
+                }
+                (true, buf)
             } else {
                 // Repo not in registry, fall back to rm -rf
                 match std::fs::remove_dir_all(&dest) {
@@ -279,6 +290,28 @@ pub fn remove_workspace_worktree(name: &str, repo_names: &[String]) {
                 }
             }
         });
+
+        if verbose {
+            for result in &results {
+                eprintln!("\x1b[2mremove {}:\x1b[0m", result.name);
+                if !result.output.is_empty() {
+                    eprint!("{}", result.output);
+                }
+                if result.success {
+                    eprintln!("  \x1b[32mok\x1b[0m");
+                }
+            }
+        } else {
+            let failures: Vec<_> = results.iter().filter(|r| !r.success).collect();
+            if failures.is_empty() {
+                eprintln!("\x1b[32mok\x1b[0m");
+            } else {
+                eprintln!("\x1b[31m{} failed\x1b[0m", failures.len());
+                for f in &failures {
+                    eprintln!("  \x1b[1m{}\x1b[0m: {}", f.name, f.output.trim());
+                }
+            }
+        }
     }
 
     // Remove session workspace root dir
@@ -352,10 +385,15 @@ pub fn ensure_workspace(
 }
 
 /// Remove workspace using the given strategy.
-pub fn remove_workspace_by_strategy(name: &str, repo_names: &[String], strategy: Strategy) {
+pub fn remove_workspace_by_strategy(
+    name: &str,
+    repo_names: &[String],
+    strategy: Strategy,
+    verbose: bool,
+) {
     match strategy {
         Strategy::Clone => remove_workspace(name),
-        Strategy::Worktree => remove_workspace_worktree(name, repo_names),
+        Strategy::Worktree => remove_workspace_worktree(name, repo_names, verbose),
     }
 }
 

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -114,6 +114,7 @@ pub fn ensure_workspace_multi(
         } else {
             for result in &results {
                 if !result.success {
+                    eprintln!("  \x1b[1m{}\x1b[0m: {}", result.name, result.output.trim());
                     failures.push(result.name.clone());
                 }
             }
@@ -208,6 +209,7 @@ pub fn ensure_workspace_multi_worktree(
         } else {
             for result in &results {
                 if !result.success {
+                    eprintln!("  \x1b[1m{}\x1b[0m: {}", result.name, result.output.trim());
                     failures.push(result.name.clone());
                 }
             }
@@ -272,13 +274,32 @@ pub fn remove_workspace_worktree(name: &str, repo_names: &[String], verbose: boo
                     .args(["-C", &path, "branch", "-D", &branch])
                     .output();
                 let mut buf = String::new();
-                if let Ok(o) = wt {
-                    buf.push_str(&captured_output(&o));
+                let mut success = true;
+                match wt {
+                    Ok(o) => {
+                        buf.push_str(&captured_output(&o));
+                        if !o.status.success() {
+                            success = false;
+                        }
+                    }
+                    Err(e) => {
+                        success = false;
+                        buf.push_str(&format!("failed to run git worktree remove: {}\n", e));
+                    }
                 }
-                if let Ok(o) = br {
-                    buf.push_str(&captured_output(&o));
+                match br {
+                    Ok(o) => {
+                        buf.push_str(&captured_output(&o));
+                        if !o.status.success() {
+                            success = false;
+                        }
+                    }
+                    Err(e) => {
+                        success = false;
+                        buf.push_str(&format!("failed to run git branch -D: {}\n", e));
+                    }
                 }
-                (true, buf)
+                (success, buf)
             } else {
                 // Repo not in registry, fall back to rm -rf
                 match std::fs::remove_dir_all(&dest) {
@@ -299,6 +320,8 @@ pub fn remove_workspace_worktree(name: &str, repo_names: &[String], verbose: boo
                 }
                 if result.success {
                     eprintln!("  \x1b[32mok\x1b[0m");
+                } else {
+                    eprintln!("  \x1b[31mfailed\x1b[0m");
                 }
             }
         } else {

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -100,7 +100,7 @@ pub fn ensure_workspace_multi(
             }
         });
 
-        let mut failures = Vec::new();
+        let mut failure_msgs = Vec::new();
         if verbose {
             for result in &results {
                 eprintln!("\x1b[2mcloning {}:\x1b[0m", result.name);
@@ -108,19 +108,22 @@ pub fn ensure_workspace_multi(
                     eprint!("{}", result.output);
                 }
                 if !result.success {
-                    failures.push(result.name.clone());
+                    failure_msgs.push(result.name.clone());
                 }
             }
         } else {
             for result in &results {
                 if !result.success {
-                    eprintln!("  \x1b[1m{}\x1b[0m: {}", result.name, result.output.trim());
-                    failures.push(result.name.clone());
+                    failure_msgs.push(format!("  {}: {}", result.name, result.output.trim()));
                 }
             }
         }
-        if !failures.is_empty() {
-            bail!("git clone --local failed for: {}", failures.join(", "));
+        if !failure_msgs.is_empty() {
+            if verbose {
+                bail!("git clone --local failed for: {}", failure_msgs.join(", "));
+            } else {
+                bail!("git clone --local failed:\n{}", failure_msgs.join("\n"));
+            }
         }
     }
 
@@ -195,7 +198,7 @@ pub fn ensure_workspace_multi_worktree(
                 }
             });
 
-        let mut failures = Vec::new();
+        let mut failure_msgs = Vec::new();
         if verbose {
             for result in &results {
                 eprintln!("\x1b[2mworktree {}:\x1b[0m", result.name);
@@ -203,19 +206,22 @@ pub fn ensure_workspace_multi_worktree(
                     eprint!("{}", result.output);
                 }
                 if !result.success {
-                    failures.push(result.name.clone());
+                    failure_msgs.push(result.name.clone());
                 }
             }
         } else {
             for result in &results {
                 if !result.success {
-                    eprintln!("  \x1b[1m{}\x1b[0m: {}", result.name, result.output.trim());
-                    failures.push(result.name.clone());
+                    failure_msgs.push(format!("  {}: {}", result.name, result.output.trim()));
                 }
             }
         }
-        if !failures.is_empty() {
-            bail!("git worktree add failed for: {}", failures.join(", "));
+        if !failure_msgs.is_empty() {
+            if verbose {
+                bail!("git worktree add failed for: {}", failure_msgs.join(", "));
+            } else {
+                bail!("git worktree add failed:\n{}", failure_msgs.join("\n"));
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Default output is now compact: single-line summaries for fetch, worktree/clone, and removal operations instead of per-repo git output
- Add `--verbose` / `-v` global flag (also `BOX_VERBOSE=1` env var) to restore full detailed output
- Applies to both `box new` and `box rm`
- Failures still surface with error details even in compact mode

**`box new` before (default):**
```
Updating repos…
captions-ops
  ok
captions-server
  ok
captions-whisper
From github.com:bungeeapp/captions-whisper
 + 5f1f10b7a...d0d4df270 ...
  ok
...
session: desktop-cert-update
repos: captions-ops, captions-server, ...
strategy: worktree

worktree captions-ops:
branch 'box/desktop-cert-update' set up to track 'origin/main'.
HEAD is now at 8092a3f ...
Preparing worktree (new branch 'box/desktop-cert-update')
...
```

**`box new` after (default):**
```
Fetching 6 repos… ok
session: desktop-cert-update (6 repos, worktree)
Creating worktrees for 6 repos… ok
```

**`box rm` after (default):**
```
Removing 6 worktrees… ok
Session 'desktop-cert-update' removed.
```

## Test plan
- [ ] `box new test --preset work` — verify compact output
- [ ] `box new test --preset work -v` — verify verbose output matches old behavior
- [ ] `box rm test` — verify compact removal output
- [ ] `box rm test -v` — verify verbose removal output
- [ ] `BOX_VERBOSE=1 box new test --preset work` — verify env var works
- [ ] Verify failures still show error details in compact mode
- [ ] `cargo test` — all 116 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)