### PR TITLE
Fix tmux rename-window targeting wrong tab from subprocess

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -887,7 +887,7 @@ box() {{
         if [[ -n "$ZELLIJ" ]]; then
             command zellij action rename-tab "$__box_name" 2>/dev/null
         elif [[ -n "$TMUX" ]]; then
-            command tmux rename-window "$__box_name" 2>/dev/null
+            command tmux rename-window -t "$TMUX_PANE" "$__box_name" 2>/dev/null
         fi
     fi
     rm -f "$__box_cd_file" "$__box_rename_file"
@@ -1030,7 +1030,7 @@ box() {{
         if [[ -n "$ZELLIJ" ]]; then
             command zellij action rename-tab "$__box_name" 2>/dev/null
         elif [[ -n "$TMUX" ]]; then
-            command tmux rename-window "$__box_name" 2>/dev/null
+            command tmux rename-window -t "$TMUX_PANE" "$__box_name" 2>/dev/null
         fi
     fi
     rm -f "$__box_cd_file" "$__box_rename_file"

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -98,44 +98,36 @@ impl TextInput {
                 self.text.insert(self.cursor, c);
                 self.cursor += c.len_utf8();
             }
-            KeyCode::Backspace => {
-                if self.cursor > 0 {
-                    let prev = self.text[..self.cursor]
-                        .char_indices()
-                        .next_back()
-                        .map(|(i, _)| i)
-                        .unwrap_or(0);
-                    self.text.drain(prev..self.cursor);
-                    self.cursor = prev;
-                }
+            KeyCode::Backspace if self.cursor > 0 => {
+                let prev = self.text[..self.cursor]
+                    .char_indices()
+                    .next_back()
+                    .map(|(i, _)| i)
+                    .unwrap_or(0);
+                self.text.drain(prev..self.cursor);
+                self.cursor = prev;
             }
-            KeyCode::Delete => {
-                if self.cursor < self.text.len() {
-                    let next = self.text[self.cursor..]
-                        .char_indices()
-                        .nth(1)
-                        .map(|(i, _)| self.cursor + i)
-                        .unwrap_or(self.text.len());
-                    self.text.drain(self.cursor..next);
-                }
+            KeyCode::Delete if self.cursor < self.text.len() => {
+                let next = self.text[self.cursor..]
+                    .char_indices()
+                    .nth(1)
+                    .map(|(i, _)| self.cursor + i)
+                    .unwrap_or(self.text.len());
+                self.text.drain(self.cursor..next);
             }
-            KeyCode::Left => {
-                if self.cursor > 0 {
-                    self.cursor = self.text[..self.cursor]
-                        .char_indices()
-                        .next_back()
-                        .map(|(i, _)| i)
-                        .unwrap_or(0);
-                }
+            KeyCode::Left if self.cursor > 0 => {
+                self.cursor = self.text[..self.cursor]
+                    .char_indices()
+                    .next_back()
+                    .map(|(i, _)| i)
+                    .unwrap_or(0);
             }
-            KeyCode::Right => {
-                if self.cursor < self.text.len() {
-                    self.cursor = self.text[self.cursor..]
-                        .char_indices()
-                        .nth(1)
-                        .map(|(i, _)| self.cursor + i)
-                        .unwrap_or(self.text.len());
-                }
+            KeyCode::Right if self.cursor < self.text.len() => {
+                self.cursor = self.text[self.cursor..]
+                    .char_indices()
+                    .nth(1)
+                    .map(|(i, _)| self.cursor + i)
+                    .unwrap_or(self.text.len());
             }
             _ => {}
         }
@@ -341,10 +333,8 @@ pub fn create_session() -> Result<TuiAction> {
                     KeyCode::Up => {
                         cursor_pos = cursor_pos.saturating_sub(1);
                     }
-                    KeyCode::Down => {
-                        if cursor_pos + 1 < preset_item_count {
-                            cursor_pos += 1;
-                        }
+                    KeyCode::Down if cursor_pos + 1 < preset_item_count => {
+                        cursor_pos += 1;
                     }
                     KeyCode::Enter => {
                         if cursor_pos < presets.len() {
@@ -400,10 +390,8 @@ pub fn create_session() -> Result<TuiAction> {
                     KeyCode::Up => {
                         cursor_pos = cursor_pos.saturating_sub(1);
                     }
-                    KeyCode::Down => {
-                        if cursor_pos + 1 < repo_count {
-                            cursor_pos += 1;
-                        }
+                    KeyCode::Down if cursor_pos + 1 < repo_count => {
+                        cursor_pos += 1;
                     }
                     KeyCode::Char(' ') => {
                         selected[cursor_pos] = !selected[cursor_pos];
@@ -598,10 +586,8 @@ fn select_repos(
                 KeyCode::Up => {
                     cursor_pos = cursor_pos.saturating_sub(1);
                 }
-                KeyCode::Down => {
-                    if cursor_pos + 1 < repo_count {
-                        cursor_pos += 1;
-                    }
+                KeyCode::Down if cursor_pos + 1 < repo_count => {
+                    cursor_pos += 1;
                 }
                 KeyCode::Char(' ') => {
                     selected[cursor_pos] = !selected[cursor_pos];
@@ -756,10 +742,8 @@ pub fn select_sessions() -> Result<TuiAction> {
                 KeyCode::Up => {
                     cursor_pos = cursor_pos.saturating_sub(1);
                 }
-                KeyCode::Down => {
-                    if cursor_pos + 1 < count {
-                        cursor_pos += 1;
-                    }
+                KeyCode::Down if cursor_pos + 1 < count => {
+                    cursor_pos += 1;
                 }
                 KeyCode::Char(' ') => {
                     selected[cursor_pos] = !selected[cursor_pos];


### PR DESCRIPTION
## Summary
- `tmux rename-window` without `-t` targets the attached client's *currently focused* window, not the window of the calling process. So a `box` command run from a subprocess in a non-focused pane (e.g. Claude Code running in Tab 2 while you're looking at Tab 1) renamed the wrong window.
- Fix: pass `-t "$TMUX_PANE"` to pin the rename to the originating pane. `$TMUX_PANE` is set per-pane by tmux and inherited by subprocesses.
- Applied in both zsh and bash wrappers; zellij path left unchanged (its `action rename-tab` has no pane-targeting flag — deferred).

### Second commit: unrelated CI fix for Rust 1.95 clippy
After pushing the fix above, CI failed because it upgraded to Rust 1.95 (released this month), which tightened the `collapsible_match` lint and flagged 8 pre-existing sites in `src/tui.rs` where `KeyCode::X => { if cond { body } }` should be written as `KeyCode::X if cond => { body }`. The second commit rewrites those arms; each falls through to the existing `_ => {}` arm when the guard is false, so behavior is preserved. Not a refactor of scope — a required fix to keep `-D warnings` green.

## Code Review
Reviewed both commits. Change 1: 2-line shell tweak, no injection risk (`$__box_name` comes from a temp file written by our own binary), `$TMUX_PANE` guaranteed present under `[[ -n "$TMUX" ]]`. Change 2: mechanical match-guard conversion, preserves the no-op fallthrough via `_ => {}`.

### Review Checklist
- [x] Formatter — `cargo fmt --check` clean
- [x] Linter / static checks — `cargo clippy --all-targets -- -D warnings` clean on Rust 1.95
- [x] Tests — 116 passed
- [x] Full diff reviewed against: correctness, error handling, performance, security, conventions, tests, dead code

### Notes for Reviewer
Zellij has the same class of bug but no `--pane-id` / `--tab-id` flag on `zellij action rename-tab` — it always targets the focused tab. Deferred per discussion; options are (1) query+focus+rename+refocus (visible flicker) or (2) skip rename when pane isn't focused.

## Test plan
- [ ] Re-source shell config (`box config zsh` / `box config bash`) to pick up the new wrapper.
- [ ] Inside tmux with ≥2 windows, focus Window 1. From Window 2, run `box switch <session>` via a subprocess (or Claude Code). Verify Window 2 gets renamed, not Window 1.
- [ ] Verify `box new` and `box switch` still rename the current window when run interactively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)