### PR TITLE
Add live progress bar for box new / box remove / fetch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "box-cli"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "box-cli"
-version = "0.1.18"
+version = "0.1.19"
 edition = "2021"
 description = "Sandboxed git workspaces for development"
 license = "MIT"

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
         box = pkgs.rustPlatform.buildRustPackage {
           pname = "box";
-          version = "0.1.18";
+          version = "0.1.19";
 
           src = ./.;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod config;
 mod git;
 mod parallel;
 mod preset;
+mod progress;
 mod repo;
 mod session;
 #[cfg(test)]
@@ -1156,16 +1157,17 @@ fn update_repos(names: &[String], verbose: bool) -> Result<()> {
     }
 
     let count = items.len();
+    let label = format!(
+        "Fetching {} repo{}",
+        count,
+        if count == 1 { "" } else { "s" }
+    );
     if verbose {
         eprintln!("\x1b[2mUpdating repos…\x1b[0m");
-    } else {
-        eprint!(
-            "\x1b[2mFetching {} repo{}…\x1b[0m ",
-            count,
-            if count == 1 { "" } else { "s" }
-        );
     }
-    let results = parallel::run_parallel(items, |_name, entry| update_repo_captured(&entry));
+    let results = progress::run_parallel_with_progress(&label, items, verbose, |_name, entry| {
+        update_repo_captured(&entry)
+    });
 
     if verbose {
         for result in &results {
@@ -1179,10 +1181,7 @@ fn update_repos(names: &[String], verbose: bool) -> Result<()> {
         }
     } else {
         let failures: Vec<&parallel::TaskResult> = results.iter().filter(|r| !r.success).collect();
-        if failures.is_empty() {
-            eprintln!("\x1b[32mok\x1b[0m");
-        } else {
-            eprintln!("\x1b[31m{} failed\x1b[0m", failures.len());
+        if !failures.is_empty() {
             for f in &failures {
                 eprintln!("  \x1b[1m{}\x1b[0m: {}", f.name, f.output.trim());
             }

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -1,3 +1,4 @@
+use std::sync::mpsc::Sender;
 use std::sync::Arc;
 use std::thread;
 
@@ -9,9 +10,44 @@ pub struct TaskResult {
     pub output: String,
 }
 
+/// Event emitted by `run_parallel_with_events` as tasks progress.
+#[derive(Clone, Debug)]
+pub enum ProgressEvent {
+    Start(String),
+    Finish(String, bool),
+}
+
 /// Run named tasks in parallel, capped at the number of available CPUs.
 /// Returns results in the same order as the input.
 pub fn run_parallel<T, F>(items: Vec<(String, T)>, task: F) -> Vec<TaskResult>
+where
+    T: Send + 'static,
+    F: Fn(&str, T) -> (bool, String) + Send + Sync + 'static,
+{
+    run_parallel_inner(items, None, task)
+}
+
+/// Like `run_parallel`, but emits a `ProgressEvent::Start` before each task
+/// and `ProgressEvent::Finish` after each completes. The channel is dropped
+/// when all tasks are finished, so receivers can use the disconnect signal
+/// to exit their render loops.
+pub fn run_parallel_with_events<T, F>(
+    items: Vec<(String, T)>,
+    tx: Sender<ProgressEvent>,
+    task: F,
+) -> Vec<TaskResult>
+where
+    T: Send + 'static,
+    F: Fn(&str, T) -> (bool, String) + Send + Sync + 'static,
+{
+    run_parallel_inner(items, Some(tx), task)
+}
+
+fn run_parallel_inner<T, F>(
+    items: Vec<(String, T)>,
+    tx: Option<Sender<ProgressEvent>>,
+    task: F,
+) -> Vec<TaskResult>
 where
     T: Send + 'static,
     F: Fn(&str, T) -> (bool, String) + Send + Sync + 'static,
@@ -28,8 +64,15 @@ where
             .map(|(name, item)| {
                 let task = Arc::clone(&task);
                 let name_clone = name.clone();
+                let tx_clone = tx.clone();
                 let handle = thread::spawn(move || {
+                    if let Some(tx) = &tx_clone {
+                        let _ = tx.send(ProgressEvent::Start(name_clone.clone()));
+                    }
                     let (success, output) = task(&name_clone, item);
+                    if let Some(tx) = &tx_clone {
+                        let _ = tx.send(ProgressEvent::Finish(name_clone.clone(), success));
+                    }
                     TaskResult {
                         name: name_clone,
                         success,
@@ -43,11 +86,16 @@ where
         for (name, handle) in handles {
             results.push(match handle.join() {
                 Ok(result) => result,
-                Err(_) => TaskResult {
-                    name,
-                    success: false,
-                    output: "thread panicked".to_string(),
-                },
+                Err(_) => {
+                    if let Some(tx) = &tx {
+                        let _ = tx.send(ProgressEvent::Finish(name.clone(), false));
+                    }
+                    TaskResult {
+                        name,
+                        success: false,
+                        output: "thread panicked".to_string(),
+                    }
+                }
             });
         }
     }
@@ -74,6 +122,7 @@ impl<T> ChunksVec<T> for Vec<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::mpsc;
 
     #[test]
     fn test_run_parallel_collects_results_in_order() {
@@ -110,5 +159,32 @@ mod tests {
         });
         assert_eq!(results[1].name, "panicker");
         assert!(!results[1].success);
+    }
+
+    #[test]
+    fn test_run_parallel_with_events_emits_start_and_finish() {
+        let (tx, rx) = mpsc::channel();
+        let items: Vec<(String, bool)> = vec![("a".into(), true), ("b".into(), false)];
+        let results =
+            run_parallel_with_events(items, tx, |_name, success| (success, String::new()));
+        assert_eq!(results.len(), 2);
+
+        let events: Vec<ProgressEvent> = rx.iter().collect();
+        // Two starts and two finishes, one per item.
+        let starts = events
+            .iter()
+            .filter(|e| matches!(e, ProgressEvent::Start(_)))
+            .count();
+        let finishes = events
+            .iter()
+            .filter(|e| matches!(e, ProgressEvent::Finish(_, _)))
+            .count();
+        assert_eq!(starts, 2);
+        assert_eq!(finishes, 2);
+        // One finish must be success=false (item "b").
+        let b_failed = events
+            .iter()
+            .any(|e| matches!(e, ProgressEvent::Finish(n, false) if n == "b"));
+        assert!(b_failed);
     }
 }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,0 +1,229 @@
+use anyhow::Result;
+use crossterm::{cursor, execute, terminal};
+use ratatui::prelude::*;
+use ratatui::{TerminalOptions, Viewport};
+use std::io::{self, IsTerminal};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use crate::parallel::{run_parallel, run_parallel_with_events, ProgressEvent, TaskResult};
+
+const SPINNER: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+const TICK: Duration = Duration::from_millis(80);
+const BAR_WIDTH: usize = 20;
+const MAX_VIEWPORT_LINES: u16 = 24;
+
+#[derive(Clone, Copy, PartialEq)]
+enum ItemState {
+    Pending,
+    Running,
+    Done,
+    Failed,
+}
+
+/// Run tasks in parallel with a live progress UI (when stderr is a TTY and
+/// `verbose` is false). Falls back to the legacy single-line `label … ok`
+/// output in verbose or non-TTY contexts. Returns results in input order.
+pub fn run_parallel_with_progress<T, F>(
+    label: &str,
+    items: Vec<(String, T)>,
+    verbose: bool,
+    task: F,
+) -> Vec<TaskResult>
+where
+    T: Send + 'static,
+    F: Fn(&str, T) -> (bool, String) + Send + Sync + 'static,
+{
+    let count = items.len();
+    if count == 0 {
+        return Vec::new();
+    }
+
+    let use_ui = !verbose && io::stderr().is_terminal();
+
+    if !use_ui {
+        if !verbose {
+            eprint!("\x1b[2m{}…\x1b[0m ", label);
+        }
+        let results = run_parallel(items, task);
+        if !verbose {
+            let failures = results.iter().filter(|r| !r.success).count();
+            if failures == 0 {
+                eprintln!("\x1b[32mok\x1b[0m");
+            } else {
+                eprintln!("\x1b[31m{} failed\x1b[0m", failures);
+            }
+        }
+        return results;
+    }
+
+    let names: Vec<String> = items.iter().map(|(n, _)| n.clone()).collect();
+    let (tx, rx) = mpsc::channel::<ProgressEvent>();
+    let label_owned = label.to_string();
+
+    let renderer: JoinHandle<()> = thread::spawn(move || {
+        if let Err(e) = render_loop(label_owned, names, rx) {
+            eprintln!("progress renderer error: {}", e);
+        }
+    });
+
+    let results = run_parallel_with_events(items, tx, task);
+    let _ = renderer.join();
+
+    let failures = results.iter().filter(|r| !r.success).count();
+    if failures == 0 {
+        eprintln!("\x1b[2m{}\x1b[0m \x1b[32mok\x1b[0m", label);
+    } else {
+        eprintln!("\x1b[2m{}\x1b[0m \x1b[31m{} failed\x1b[0m", label, failures);
+    }
+    results
+}
+
+fn render_loop(label: String, names: Vec<String>, rx: Receiver<ProgressEvent>) -> Result<()> {
+    let total = names.len();
+    let term_height = terminal::size().map(|(_, h)| h).unwrap_or(24);
+    let desired = (total as u16).saturating_add(1);
+    let viewport_height = desired
+        .min(MAX_VIEWPORT_LINES)
+        .min(term_height.saturating_sub(1).max(2));
+
+    terminal::enable_raw_mode()?;
+    let _guard = RawGuard;
+
+    let options = TerminalOptions {
+        viewport: Viewport::Inline(viewport_height),
+    };
+    let mut terminal = Terminal::with_options(CrosstermBackend::new(io::stderr()), options)?;
+
+    let mut states: Vec<(String, ItemState)> =
+        names.into_iter().map(|n| (n, ItemState::Pending)).collect();
+
+    let mut frame: usize = 0;
+    let mut disconnected = false;
+
+    loop {
+        // Wait up to one tick for an event, then drain any additional events
+        // that arrived during the same burst. The timeout drives spinner animation.
+        match rx.recv_timeout(TICK) {
+            Ok(ev) => {
+                apply_event(&mut states, ev);
+                while let Ok(ev) = rx.try_recv() {
+                    apply_event(&mut states, ev);
+                }
+            }
+            Err(RecvTimeoutError::Timeout) => {}
+            Err(RecvTimeoutError::Disconnected) => disconnected = true,
+        }
+
+        draw(&mut terminal, &label, &states, frame)?;
+        frame = frame.wrapping_add(1);
+
+        if disconnected {
+            break;
+        }
+    }
+
+    // Erase the inline viewport so the final summary line can take its place.
+    terminal.clear()?;
+    execute!(
+        io::stderr(),
+        cursor::MoveUp(viewport_height),
+        terminal::Clear(terminal::ClearType::FromCursorDown),
+    )?;
+    Ok(())
+}
+
+fn apply_event(states: &mut [(String, ItemState)], ev: ProgressEvent) {
+    match ev {
+        ProgressEvent::Start(name) => {
+            if let Some(e) = states.iter_mut().find(|(n, _)| n == &name) {
+                e.1 = ItemState::Running;
+            }
+        }
+        ProgressEvent::Finish(name, success) => {
+            if let Some(e) = states.iter_mut().find(|(n, _)| n == &name) {
+                e.1 = if success {
+                    ItemState::Done
+                } else {
+                    ItemState::Failed
+                };
+            }
+        }
+    }
+}
+
+fn draw(
+    terminal: &mut Terminal<CrosstermBackend<io::Stderr>>,
+    label: &str,
+    states: &[(String, ItemState)],
+    frame: usize,
+) -> Result<()> {
+    let total = states.len();
+    let done = states
+        .iter()
+        .filter(|(_, s)| matches!(s, ItemState::Done | ItemState::Failed))
+        .count();
+    let pct = (done * 100).checked_div(total).unwrap_or(100);
+    let filled = (done * BAR_WIDTH).checked_div(total).unwrap_or(BAR_WIDTH);
+    let bar: String = "█".repeat(filled) + &"░".repeat(BAR_WIDTH - filled);
+    let spinner_frame = SPINNER[frame % SPINNER.len()];
+    let active = done < total;
+
+    terminal.draw(|f| {
+        let area = f.area();
+        if area.height == 0 {
+            return;
+        }
+
+        let (head_icon, head_color) = if active {
+            (spinner_frame, Color::Cyan)
+        } else {
+            ("✓", Color::Green)
+        };
+        let header = Line::from(vec![
+            Span::styled(head_icon.to_string(), Style::default().fg(head_color)),
+            Span::raw(" "),
+            Span::styled(label.to_string(), Style::default().bold()),
+            Span::raw(" "),
+            Span::styled(format!("[{}]", bar), Style::default().fg(Color::Cyan)),
+            Span::raw(format!(" {}/{} ", done, total)),
+            Span::styled(format!("({}%)", pct), Style::default().fg(Color::DarkGray)),
+        ]);
+        f.render_widget(header, Rect::new(area.x, area.y, area.width, 1));
+
+        let max_rows = area.height.saturating_sub(1) as usize;
+        for (i, (name, state)) in states.iter().take(max_rows).enumerate() {
+            let (icon, color) = match state {
+                ItemState::Pending => ("·", Color::DarkGray),
+                ItemState::Running => (spinner_frame, Color::Cyan),
+                ItemState::Done => ("✓", Color::Green),
+                ItemState::Failed => ("✗", Color::Red),
+            };
+            let name_style = match state {
+                ItemState::Pending => Style::default().fg(Color::DarkGray),
+                ItemState::Failed => Style::default().fg(Color::Red),
+                _ => Style::default(),
+            };
+            let line = Line::from(vec![
+                Span::raw("  "),
+                Span::styled(icon.to_string(), Style::default().fg(color)),
+                Span::raw(" "),
+                Span::styled(name.clone(), name_style),
+            ]);
+            let y = area.y + (i as u16) + 1;
+            if y < area.y + area.height {
+                f.render_widget(line, Rect::new(area.x, y, area.width, 1));
+            }
+        }
+    })?;
+    Ok(())
+}
+
+struct RawGuard;
+
+impl Drop for RawGuard {
+    fn drop(&mut self) {
+        let _ = terminal::disable_raw_mode();
+    }
+}

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -79,26 +79,40 @@ pub fn ensure_workspace_multi(
 
     if !to_clone.is_empty() {
         let root_str = root.to_string_lossy().to_string();
-        let results = crate::parallel::run_parallel(to_clone, move |_name, (repo, dest_str)| {
-            let result = Command::new("git")
-                .args(["clone", "--local", &repo.path, &dest_str])
-                .current_dir(&root_str)
-                .env("GIT_TERMINAL_PROMPT", "0")
-                .output();
-            match result {
-                Ok(output) => {
-                    let mut buf = captured_output(&output);
-                    if output.status.success() {
-                        repoint_origin(&repo.path, &dest_str);
-                        (true, buf)
-                    } else {
-                        buf.push_str(&format!("git clone --local failed for '{}'\n", repo.name));
-                        (false, buf)
+        let count = to_clone.len();
+        let label = format!(
+            "Cloning {} repo{}",
+            count,
+            if count == 1 { "" } else { "s" }
+        );
+        let results = crate::progress::run_parallel_with_progress(
+            &label,
+            to_clone,
+            verbose,
+            move |_name, (repo, dest_str)| {
+                let result = Command::new("git")
+                    .args(["clone", "--local", &repo.path, &dest_str])
+                    .current_dir(&root_str)
+                    .env("GIT_TERMINAL_PROMPT", "0")
+                    .output();
+                match result {
+                    Ok(output) => {
+                        let mut buf = captured_output(&output);
+                        if output.status.success() {
+                            repoint_origin(&repo.path, &dest_str);
+                            (true, buf)
+                        } else {
+                            buf.push_str(&format!(
+                                "git clone --local failed for '{}'\n",
+                                repo.name
+                            ));
+                            (false, buf)
+                        }
                     }
+                    Err(e) => (false, format!("failed to run git: {}\n", e)),
                 }
-                Err(e) => (false, format!("failed to run git: {}\n", e)),
-            }
-        });
+            },
+        );
 
         let mut failure_msgs = Vec::new();
         if verbose {
@@ -162,8 +176,17 @@ pub fn ensure_workspace_multi_worktree(
         .collect();
 
     if !to_create.is_empty() {
-        let results =
-            crate::parallel::run_parallel(to_create, |_name, (repo, dest_str, branch)| {
+        let count = to_create.len();
+        let label = format!(
+            "Creating {} worktree{}",
+            count,
+            if count == 1 { "" } else { "s" }
+        );
+        let results = crate::progress::run_parallel_with_progress(
+            &label,
+            to_create,
+            verbose,
+            |_name, (repo, dest_str, branch)| {
                 // Try with -b first to create a new branch
                 let result = Command::new("git")
                     .args([
@@ -196,7 +219,8 @@ pub fn ensure_workspace_multi_worktree(
                     }
                     Err(e) => (false, format!("failed to run git: {}\n", e)),
                 }
-            });
+            },
+        );
 
         let mut failure_msgs = Vec::new();
         if verbose {
@@ -261,62 +285,65 @@ pub fn remove_workspace_worktree(name: &str, repo_names: &[String], verbose: boo
 
     if !items.is_empty() {
         let count = items.len();
-        if !verbose {
-            eprint!(
-                "\x1b[2mRemoving {} worktree{}…\x1b[0m ",
-                count,
-                if count == 1 { "" } else { "s" }
-            );
-        }
-        let results = crate::parallel::run_parallel(items, |_name, (repo_path, dest, branch)| {
-            if let Some(path) = repo_path {
-                let dest_str = dest.to_string_lossy().to_string();
-                // Remove worktree via git
-                let wt = Command::new("git")
-                    .args(["-C", &path, "worktree", "remove", "--force", &dest_str])
-                    .output();
-                // Delete the branch
-                let br = Command::new("git")
-                    .args(["-C", &path, "branch", "-D", &branch])
-                    .output();
-                let mut buf = String::new();
-                let mut success = true;
-                match wt {
-                    Ok(o) => {
-                        buf.push_str(&captured_output(&o));
-                        if !o.status.success() {
+        let label = format!(
+            "Removing {} worktree{}",
+            count,
+            if count == 1 { "" } else { "s" }
+        );
+        let results = crate::progress::run_parallel_with_progress(
+            &label,
+            items,
+            verbose,
+            |_name, (repo_path, dest, branch)| {
+                if let Some(path) = repo_path {
+                    let dest_str = dest.to_string_lossy().to_string();
+                    // Remove worktree via git
+                    let wt = Command::new("git")
+                        .args(["-C", &path, "worktree", "remove", "--force", &dest_str])
+                        .output();
+                    // Delete the branch
+                    let br = Command::new("git")
+                        .args(["-C", &path, "branch", "-D", &branch])
+                        .output();
+                    let mut buf = String::new();
+                    let mut success = true;
+                    match wt {
+                        Ok(o) => {
+                            buf.push_str(&captured_output(&o));
+                            if !o.status.success() {
+                                success = false;
+                            }
+                        }
+                        Err(e) => {
                             success = false;
+                            buf.push_str(&format!("failed to run git worktree remove: {}\n", e));
                         }
                     }
-                    Err(e) => {
-                        success = false;
-                        buf.push_str(&format!("failed to run git worktree remove: {}\n", e));
-                    }
-                }
-                match br {
-                    Ok(o) => {
-                        buf.push_str(&captured_output(&o));
-                        if !o.status.success() {
+                    match br {
+                        Ok(o) => {
+                            buf.push_str(&captured_output(&o));
+                            if !o.status.success() {
+                                success = false;
+                            }
+                        }
+                        Err(e) => {
                             success = false;
+                            buf.push_str(&format!("failed to run git branch -D: {}\n", e));
                         }
                     }
-                    Err(e) => {
-                        success = false;
-                        buf.push_str(&format!("failed to run git branch -D: {}\n", e));
+                    (success, buf)
+                } else {
+                    // Repo not in registry, fall back to rm -rf
+                    match std::fs::remove_dir_all(&dest) {
+                        Ok(()) => (true, String::new()),
+                        Err(e) => (
+                            false,
+                            format!("failed to remove '{}': {}", dest.display(), e),
+                        ),
                     }
                 }
-                (success, buf)
-            } else {
-                // Repo not in registry, fall back to rm -rf
-                match std::fs::remove_dir_all(&dest) {
-                    Ok(()) => (true, String::new()),
-                    Err(e) => (
-                        false,
-                        format!("failed to remove '{}': {}", dest.display(), e),
-                    ),
-                }
-            }
-        });
+            },
+        );
 
         if verbose {
             for result in &results {
@@ -332,10 +359,7 @@ pub fn remove_workspace_worktree(name: &str, repo_names: &[String], verbose: boo
             }
         } else {
             let failures: Vec<_> = results.iter().filter(|r| !r.success).collect();
-            if failures.is_empty() {
-                eprintln!("\x1b[32mok\x1b[0m");
-            } else {
-                eprintln!("\x1b[31m{} failed\x1b[0m", failures.len());
+            if !failures.is_empty() {
                 for f in &failures {
                     eprintln!("  \x1b[1m{}\x1b[0m: {}", f.name, f.output.trim());
                 }
@@ -387,30 +411,10 @@ pub fn ensure_workspace(
     strategy: Strategy,
     verbose: bool,
 ) -> Result<String> {
-    let count = repos.len();
-    let label = match strategy {
-        Strategy::Clone => "Cloning",
-        Strategy::Worktree => "Creating worktrees",
-    };
-    if !verbose {
-        eprint!(
-            "\x1b[2m{} for {} repo{}…\x1b[0m ",
-            label,
-            count,
-            if count == 1 { "" } else { "s" }
-        );
-    }
-    let result = match strategy {
+    match strategy {
         Strategy::Clone => ensure_workspace_multi(name, repos, verbose),
         Strategy::Worktree => ensure_workspace_multi_worktree(name, repos, verbose),
-    };
-    if !verbose {
-        match &result {
-            Ok(_) => eprintln!("\x1b[32mok\x1b[0m"),
-            Err(_) => eprintln!("\x1b[31mfailed\x1b[0m"),
-        }
     }
-    result
 }
 
 /// Remove workspace using the given strategy.


### PR DESCRIPTION
## Summary
- Clone, worktree-create, and worktree-remove operations now render a live ratatui inline viewport with a braille spinner, filled progress bar, `done/total` count, and percentage.
- Each repo gets a per-line status indicator: `·` pending, spinner running, `✓` done, `✗` failed.
- Falls back to the prior single-line `label… ok / N failed` output when stderr is not a TTY or `--verbose` is passed (verbose still shows per-repo output after completion).
- New `progress` module sits on top of a new `parallel::run_parallel_with_events` variant that emits `ProgressEvent::Start` / `ProgressEvent::Finish` over an mpsc channel.

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy --all-targets` (clean)
- [x] `cargo test` (120 passed)
- [x] `cargo build --release`
- [ ] Manual: `box new <name> --preset <multi-repo>` shows the live bar
- [ ] Manual: `box remove <name>` on a worktree session shows the live bar
- [ ] Manual: piping stderr to a file falls back to the single-line output
- [ ] Manual: `--verbose` prints per-repo details after completion (no live bar)

v0.1.19

🤖 Generated with [Claude Code](https://claude.com/claude-code)