### PR TITLE
Unify fetch + worktree-add into a single progress bar for box new

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "box-cli"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "box-cli"
-version = "0.1.19"
+version = "0.1.20"
 edition = "2021"
 description = "Sandboxed git workspaces for development"
 license = "MIT"

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
         box = pkgs.rustPlatform.buildRustPackage {
           pname = "box";
-          version = "0.1.19";
+          version = "0.1.20";
 
           src = ./.;
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -18,6 +18,108 @@ pub fn find_root(dir: &Path) -> Option<&Path> {
     }
 }
 
+/// Fetch all refs for a bare repo, capturing output.
+///
+/// When worktrees have branches checked out, git refuses to update those refs
+/// via fetch. We detect checked-out branches and exclude them with negative
+/// refspecs. If git still refuses (e.g. a worktree admin entry we missed),
+/// we parse the error, add the offending branch to the excludes, and retry.
+///
+/// Returns (success, captured_output) for use in parallel execution.
+pub fn fetch_repo(entry: &crate::repo::RepoEntry) -> (bool, String) {
+    let mut excludes = worktree_checked_out_branches(&entry.path);
+    let mut log = String::new();
+
+    for _ in 0..8 {
+        let mut args: Vec<String> = vec![
+            "-C".into(),
+            entry.path.clone(),
+            "fetch".into(),
+            "origin".into(),
+            "+refs/heads/*:refs/heads/*".into(),
+        ];
+        for branch in &excludes {
+            args.push(format!("^refs/heads/{}", branch));
+        }
+
+        let result = std::process::Command::new("git")
+            .args(args.iter().map(|s| s.as_str()).collect::<Vec<_>>())
+            .env("GIT_TERMINAL_PROMPT", "0")
+            .output();
+
+        let output = match result {
+            Ok(o) => o,
+            Err(e) => {
+                log.push_str(&format!("  \x1b[31mfetch error: {}\x1b[0m\n", e));
+                return (false, log);
+            }
+        };
+
+        let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+        let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+
+        if output.status.success() {
+            log.push_str(&stdout);
+            log.push_str(&stderr);
+            return (true, log);
+        }
+
+        let new_excludes = parse_refused_branches(&stderr);
+        let added: Vec<String> = new_excludes
+            .into_iter()
+            .filter(|b| !excludes.contains(b))
+            .collect();
+
+        if added.is_empty() {
+            log.push_str(&stdout);
+            log.push_str(&stderr);
+            log.push_str("  \x1b[31mfetch failed\x1b[0m\n");
+            return (false, log);
+        }
+
+        excludes.extend(added);
+    }
+
+    log.push_str("  \x1b[31mfetch failed: too many checked-out branches to exclude\x1b[0m\n");
+    (false, log)
+}
+
+/// Return branch names currently checked out in any worktree of the given repo.
+fn worktree_checked_out_branches(bare_path: &str) -> Vec<String> {
+    let output = std::process::Command::new("git")
+        .args(["-C", bare_path, "worktree", "list", "--porcelain"])
+        .output();
+    let Ok(output) = output else {
+        return Vec::new();
+    };
+    let text = String::from_utf8_lossy(&output.stdout);
+    text.lines()
+        .filter_map(|l| l.strip_prefix("branch refs/heads/"))
+        .map(String::from)
+        .collect()
+}
+
+/// Extract branch names from git's "refusing to fetch into branch 'refs/heads/X'
+/// checked out at..." error lines.
+fn parse_refused_branches(stderr: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    for line in stderr.lines() {
+        let Some(rest) = line
+            .split_once("refusing to fetch into branch '")
+            .map(|s| s.1)
+        else {
+            continue;
+        };
+        let Some((ref_name, _)) = rest.split_once('\'') else {
+            continue;
+        };
+        if let Some(branch) = ref_name.strip_prefix("refs/heads/") {
+            out.push(branch.to_string());
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -85,5 +187,24 @@ mod tests {
         let sub = tmp.path().join("no_repo");
         std::fs::create_dir_all(&sub).unwrap();
         assert_eq!(find_root(&sub), None);
+    }
+
+    #[test]
+    fn test_parse_refused_branches_single() {
+        let stderr = "fatal: refusing to fetch into branch 'refs/heads/box/conformance-2' checked out at '/Users/yusuke/.box/workspaces/conformance-2/jerboa'\n";
+        assert_eq!(parse_refused_branches(stderr), vec!["box/conformance-2"]);
+    }
+
+    #[test]
+    fn test_parse_refused_branches_multiple() {
+        let stderr = "fatal: refusing to fetch into branch 'refs/heads/a' checked out at '/x'\n\
+                      fatal: refusing to fetch into branch 'refs/heads/feat/b' checked out at '/y'\n";
+        assert_eq!(parse_refused_branches(stderr), vec!["a", "feat/b"]);
+    }
+
+    #[test]
+    fn test_parse_refused_branches_ignores_unrelated() {
+        let stderr = "From github.com:org/repo\n   abc..def  main -> main\n";
+        assert!(parse_refused_branches(stderr).is_empty());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -319,12 +319,7 @@ fn cmd_default(verbose: bool) -> Result<i32> {
 fn cmd_create_tui(verbose: bool) -> Result<i32> {
     let strategy = workspace::Strategy::resolve(None)?;
     match tui::create_session()? {
-        tui::TuiAction::New { name, repos } => {
-            if let Err(e) = update_repos(&repos, verbose) {
-                eprintln!("Warning: repo update failed: {}", e);
-            }
-            cmd_create(&name, repos, strategy, verbose)
-        }
+        tui::TuiAction::New { name, repos } => cmd_create(&name, repos, strategy, true, verbose),
         _ => Ok(0),
     }
 }
@@ -418,17 +413,15 @@ fn cmd_new(args: CreateArgs, verbose: bool) -> Result<i32> {
     } else {
         bail!("Either --repo or --preset is required.");
     };
-    if let Err(e) = update_repos(&repo_names, verbose) {
-        eprintln!("Warning: repo update failed: {}", e);
-    }
     let strategy = workspace::Strategy::from_str(&args.strategy)?;
-    cmd_create(&args.name, repo_names, strategy, verbose)
+    cmd_create(&args.name, repo_names, strategy, true, verbose)
 }
 
 fn cmd_create(
     name: &str,
     repo_names: Vec<String>,
     strategy: workspace::Strategy,
+    fetch: bool,
     verbose: bool,
 ) -> Result<i32> {
     let name = session::validate_name(name)?;
@@ -484,7 +477,8 @@ fn cmd_create(
     sess.strategy = strategy.as_str().to_string();
     session::save(&sess)?;
 
-    let workspace_path = workspace::ensure_workspace(name, &selected_repos, strategy, verbose)?;
+    let workspace_path =
+        workspace::ensure_workspace(name, &selected_repos, strategy, fetch, verbose)?;
     if selected_repos.len() == 1 {
         let repo_path = Path::new(&workspace_path).join(&selected_repos[0].name);
         output_cd_path(&repo_path.to_string_lossy());
@@ -530,7 +524,7 @@ fn cmd_edit(name: &str, verbose: bool) -> Result<i32> {
                     .iter()
                     .filter_map(|name| all_repos.iter().find(|r| r.name == *name).cloned())
                     .collect();
-                workspace::ensure_workspace(name, &repos_to_add, strategy, verbose)?;
+                workspace::ensure_workspace(name, &repos_to_add, strategy, false, verbose)?;
             }
 
             // Remove workspace directories for removed repos
@@ -1040,155 +1034,6 @@ box() {{
 "#
     );
     Ok(0)
-}
-
-/// Fetch all refs for a bare repo, capturing output.
-///
-/// When worktrees have branches checked out, git refuses to update those refs
-/// via fetch. We detect checked-out branches and exclude them with negative
-/// refspecs. If git still refuses (e.g. a worktree admin entry we missed),
-/// we parse the error, add the offending branch to the excludes, and retry.
-///
-/// Returns (success, captured_output) for use in parallel execution.
-fn update_repo_captured(entry: &repo::RepoEntry) -> (bool, String) {
-    let mut excludes = worktree_checked_out_branches(&entry.path);
-    let mut log = String::new();
-
-    for _ in 0..8 {
-        let mut args: Vec<String> = vec![
-            "-C".into(),
-            entry.path.clone(),
-            "fetch".into(),
-            "origin".into(),
-            "+refs/heads/*:refs/heads/*".into(),
-        ];
-        for branch in &excludes {
-            args.push(format!("^refs/heads/{}", branch));
-        }
-
-        let result = std::process::Command::new("git")
-            .args(args.iter().map(|s| s.as_str()).collect::<Vec<_>>())
-            .env("GIT_TERMINAL_PROMPT", "0")
-            .output();
-
-        let output = match result {
-            Ok(o) => o,
-            Err(e) => {
-                log.push_str(&format!("  \x1b[31mfetch error: {}\x1b[0m\n", e));
-                return (false, log);
-            }
-        };
-
-        let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
-        let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
-
-        if output.status.success() {
-            log.push_str(&stdout);
-            log.push_str(&stderr);
-            return (true, log);
-        }
-
-        let new_excludes = parse_refused_branches(&stderr);
-        let added: Vec<String> = new_excludes
-            .into_iter()
-            .filter(|b| !excludes.contains(b))
-            .collect();
-
-        if added.is_empty() {
-            log.push_str(&stdout);
-            log.push_str(&stderr);
-            log.push_str("  \x1b[31mfetch failed\x1b[0m\n");
-            return (false, log);
-        }
-
-        excludes.extend(added);
-    }
-
-    log.push_str("  \x1b[31mfetch failed: too many checked-out branches to exclude\x1b[0m\n");
-    (false, log)
-}
-
-/// Return branch names currently checked out in any worktree of the given repo.
-fn worktree_checked_out_branches(bare_path: &str) -> Vec<String> {
-    let output = std::process::Command::new("git")
-        .args(["-C", bare_path, "worktree", "list", "--porcelain"])
-        .output();
-    let Ok(output) = output else {
-        return Vec::new();
-    };
-    let text = String::from_utf8_lossy(&output.stdout);
-    text.lines()
-        .filter_map(|l| l.strip_prefix("branch refs/heads/"))
-        .map(String::from)
-        .collect()
-}
-
-/// Extract branch names from git's "refusing to fetch into branch 'refs/heads/X'
-/// checked out at..." error lines.
-fn parse_refused_branches(stderr: &str) -> Vec<String> {
-    let mut out = Vec::new();
-    for line in stderr.lines() {
-        let Some(rest) = line
-            .split_once("refusing to fetch into branch '")
-            .map(|s| s.1)
-        else {
-            continue;
-        };
-        let Some((ref_name, _)) = rest.split_once('\'') else {
-            continue;
-        };
-        if let Some(branch) = ref_name.strip_prefix("refs/heads/") {
-            out.push(branch.to_string());
-        }
-    }
-    out
-}
-
-/// Fetch named repos in parallel.
-fn update_repos(names: &[String], verbose: bool) -> Result<()> {
-    let all_repos = repo::list()?;
-    let items: Vec<(String, repo::RepoEntry)> = all_repos
-        .into_iter()
-        .filter(|r| names.contains(&r.name))
-        .map(|r| (r.name.clone(), r))
-        .collect();
-    if items.is_empty() {
-        return Ok(());
-    }
-
-    let count = items.len();
-    let label = format!(
-        "Fetching {} repo{}",
-        count,
-        if count == 1 { "" } else { "s" }
-    );
-    if verbose {
-        eprintln!("\x1b[2mUpdating repos…\x1b[0m");
-    }
-    let results = progress::run_parallel_with_progress(&label, items, verbose, |_name, entry| {
-        update_repo_captured(&entry)
-    });
-
-    if verbose {
-        for result in &results {
-            eprintln!("\x1b[1m{}\x1b[0m", result.name);
-            if !result.output.is_empty() {
-                eprint!("{}", result.output);
-            }
-            if result.success {
-                eprintln!("  \x1b[32mok\x1b[0m");
-            }
-        }
-    } else {
-        let failures: Vec<&parallel::TaskResult> = results.iter().filter(|r| !r.success).collect();
-        if !failures.is_empty() {
-            for f in &failures {
-                eprintln!("  \x1b[1m{}\x1b[0m: {}", f.name, f.output.trim());
-            }
-        }
-    }
-
-    Ok(())
 }
 
 fn cmd_upgrade() -> Result<i32> {
@@ -1747,24 +1592,5 @@ mod tests {
     fn test_bare_name_rejected() {
         let result = try_parse(&["my-session"]);
         assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_parse_refused_branches_single() {
-        let stderr = "fatal: refusing to fetch into branch 'refs/heads/box/conformance-2' checked out at '/Users/yusuke/.box/workspaces/conformance-2/jerboa'\n";
-        assert_eq!(parse_refused_branches(stderr), vec!["box/conformance-2"]);
-    }
-
-    #[test]
-    fn test_parse_refused_branches_multiple() {
-        let stderr = "fatal: refusing to fetch into branch 'refs/heads/a' checked out at '/x'\n\
-                      fatal: refusing to fetch into branch 'refs/heads/feat/b' checked out at '/y'\n";
-        assert_eq!(parse_refused_branches(stderr), vec!["a", "feat/b"]);
-    }
-
-    #[test]
-    fn test_parse_refused_branches_ignores_unrelated() {
-        let stderr = "From github.com:org/repo\n   abc..def  main -> main\n";
-        assert!(parse_refused_branches(stderr).is_empty());
     }
 }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -52,9 +52,14 @@ pub fn remove_workspace(name: &str) {
 }
 
 /// Create a multi-repo workspace using git clone --local.
+///
+/// When `fetch` is true, each repo is fetched from `origin` before cloning so
+/// the session picks up the latest upstream refs; fetch failures are
+/// captured but do not abort the clone.
 pub fn ensure_workspace_multi(
     session_name: &str,
     repos: &[crate::repo::RepoEntry],
+    fetch: bool,
     verbose: bool,
 ) -> Result<String> {
     let root = config::box_root()?.join("workspaces").join(session_name);
@@ -80,16 +85,33 @@ pub fn ensure_workspace_multi(
     if !to_clone.is_empty() {
         let root_str = root.to_string_lossy().to_string();
         let count = to_clone.len();
-        let label = format!(
-            "Cloning {} repo{}",
-            count,
-            if count == 1 { "" } else { "s" }
-        );
+        let label = if fetch {
+            format!(
+                "Preparing {} repo{}",
+                count,
+                if count == 1 { "" } else { "s" }
+            )
+        } else {
+            format!(
+                "Cloning {} repo{}",
+                count,
+                if count == 1 { "" } else { "s" }
+            )
+        };
         let results = crate::progress::run_parallel_with_progress(
             &label,
             to_clone,
             verbose,
             move |_name, (repo, dest_str)| {
+                let mut buf = String::new();
+                if fetch {
+                    let (ok, fetch_log) = crate::git::fetch_repo(&repo);
+                    buf.push_str(&fetch_log);
+                    if !ok {
+                        buf.push_str("  \x1b[33mfetch failed; cloning local refs\x1b[0m\n");
+                    }
+                }
+
                 let result = Command::new("git")
                     .args(["clone", "--local", &repo.path, &dest_str])
                     .current_dir(&root_str)
@@ -97,7 +119,7 @@ pub fn ensure_workspace_multi(
                     .output();
                 match result {
                     Ok(output) => {
-                        let mut buf = captured_output(&output);
+                        buf.push_str(&captured_output(&output));
                         if output.status.success() {
                             repoint_origin(&repo.path, &dest_str);
                             (true, buf)
@@ -109,7 +131,10 @@ pub fn ensure_workspace_multi(
                             (false, buf)
                         }
                     }
-                    Err(e) => (false, format!("failed to run git: {}\n", e)),
+                    Err(e) => {
+                        buf.push_str(&format!("failed to run git: {}\n", e));
+                        (false, buf)
+                    }
                 }
             },
         );
@@ -145,9 +170,14 @@ pub fn ensure_workspace_multi(
 }
 
 /// Create a multi-repo workspace using git worktree add.
+///
+/// When `fetch` is true, each source repo is fetched from `origin` before the
+/// worktree is created so the new branch starts from the latest upstream;
+/// fetch failures are captured but do not abort the worktree creation.
 pub fn ensure_workspace_multi_worktree(
     session_name: &str,
     repos: &[crate::repo::RepoEntry],
+    fetch: bool,
     verbose: bool,
 ) -> Result<String> {
     let root = config::box_root()?.join("workspaces").join(session_name);
@@ -177,16 +207,33 @@ pub fn ensure_workspace_multi_worktree(
 
     if !to_create.is_empty() {
         let count = to_create.len();
-        let label = format!(
-            "Creating {} worktree{}",
-            count,
-            if count == 1 { "" } else { "s" }
-        );
+        let label = if fetch {
+            format!(
+                "Preparing {} repo{}",
+                count,
+                if count == 1 { "" } else { "s" }
+            )
+        } else {
+            format!(
+                "Creating {} worktree{}",
+                count,
+                if count == 1 { "" } else { "s" }
+            )
+        };
         let results = crate::progress::run_parallel_with_progress(
             &label,
             to_create,
             verbose,
-            |_name, (repo, dest_str, branch)| {
+            move |_name, (repo, dest_str, branch)| {
+                let mut buf = String::new();
+                if fetch {
+                    let (ok, fetch_log) = crate::git::fetch_repo(&repo);
+                    buf.push_str(&fetch_log);
+                    if !ok {
+                        buf.push_str("  \x1b[33mfetch failed; branching from local HEAD\x1b[0m\n");
+                    }
+                }
+
                 // Try with -b first to create a new branch
                 let result = Command::new("git")
                     .args([
@@ -196,9 +243,12 @@ pub fn ensure_workspace_multi_worktree(
                     .output();
 
                 match result {
-                    Ok(output) if output.status.success() => (true, captured_output(&output)),
+                    Ok(output) if output.status.success() => {
+                        buf.push_str(&captured_output(&output));
+                        (true, buf)
+                    }
                     Ok(first_output) => {
-                        let first_err = captured_output(&first_output);
+                        buf.push_str(&captured_output(&first_output));
                         // Branch may already exist from a partial retry; try without -b
                         match Command::new("git")
                             .args(["-C", &repo.path, "worktree", "add", &dest_str, &branch])
@@ -206,18 +256,19 @@ pub fn ensure_workspace_multi_worktree(
                             .output()
                         {
                             Ok(output2) => {
-                                let mut buf = first_err;
                                 buf.push_str(&captured_output(&output2));
                                 (output2.status.success(), buf)
                             }
                             Err(e) => {
-                                let mut buf = first_err;
                                 buf.push_str(&format!("failed to run git: {}\n", e));
                                 (false, buf)
                             }
                         }
                     }
-                    Err(e) => (false, format!("failed to run git: {}\n", e)),
+                    Err(e) => {
+                        buf.push_str(&format!("failed to run git: {}\n", e));
+                        (false, buf)
+                    }
                 }
             },
         );
@@ -409,11 +460,12 @@ pub fn ensure_workspace(
     name: &str,
     repos: &[crate::repo::RepoEntry],
     strategy: Strategy,
+    fetch: bool,
     verbose: bool,
 ) -> Result<String> {
     match strategy {
-        Strategy::Clone => ensure_workspace_multi(name, repos, verbose),
-        Strategy::Worktree => ensure_workspace_multi_worktree(name, repos, verbose),
+        Strategy::Clone => ensure_workspace_multi(name, repos, fetch, verbose),
+        Strategy::Worktree => ensure_workspace_multi_worktree(name, repos, fetch, verbose),
     }
 }
 


### PR DESCRIPTION
## Summary
- `box new` previously showed two sequential progress bars: "Fetching N repos" then "Creating N worktrees" (or "Cloning N repos"). Each repo now runs fetch → worktree-add (or clone) back-to-back in one task, surfaced as a single "Preparing N repos" bar.
- Fetch remains best-effort: a per-repo fetch failure is captured in the output with a dim yellow warning but doesn't abort the worktree/clone for that repo.
- `box edit` (adding repos to an existing session) keeps its prior behavior — it skips the fetch and uses the strategy-specific label ("Creating N worktrees" / "Cloning N repos").
- Moved `fetch_repo` (formerly `update_repo_captured`), `worktree_checked_out_branches`, and `parse_refused_branches` from `main.rs` into `git.rs` alongside their tests.

v0.1.20

## Test plan
- [ ] `box new <name> --repo <a> --repo <b>` shows one "Preparing 2 repos" bar that ticks green per repo and falls back to the single-line summary in non-TTY / `--verbose` mode
- [ ] `box edit <name>` adding a repo still shows the prior "Creating N worktrees" label (no fetch)
- [ ] Simulated fetch failure (e.g. unreachable origin) still creates the worktree with a yellow warning in the captured output
- [ ] \`cargo fmt\`, \`cargo clippy -D warnings\`, \`cargo test\` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)