### PR TITLE
Unify box rm progress bar across all selected sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "box-cli"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "box-cli"
-version = "0.1.21"
+version = "0.1.22"
 edition = "2021"
 description = "Sandboxed git workspaces for development"
 license = "MIT"

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
         box = pkgs.rustPlatform.buildRustPackage {
           pname = "box";
-          version = "0.1.21";
+          version = "0.1.22";
 
           src = ./.;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -563,7 +563,7 @@ fn cmd_remove(name: &str, verbose: bool) -> Result<i32> {
     let strategy =
         workspace::Strategy::from_str(&sess.strategy).unwrap_or(workspace::Strategy::Clone);
 
-    workspace::remove_workspace_by_strategy(name, &sess.repos, strategy, verbose);
+    workspace::remove_sessions(&[(name.to_string(), strategy, sess.repos.clone())], verbose);
     session::remove_dir(name)?;
 
     if !sess.project_dir.is_empty() {
@@ -576,14 +576,21 @@ fn cmd_remove(name: &str, verbose: bool) -> Result<i32> {
 fn cmd_remove_tui(verbose: bool) -> Result<i32> {
     match tui::select_sessions()? {
         tui::TuiAction::Remove { sessions } => {
+            let to_remove: Vec<(String, workspace::Strategy, Vec<String>)> = sessions
+                .iter()
+                .map(|name| match session::load(name) {
+                    Ok(sess) => {
+                        let strategy = workspace::Strategy::from_str(&sess.strategy)
+                            .unwrap_or(workspace::Strategy::Clone);
+                        (name.clone(), strategy, sess.repos)
+                    }
+                    // Session metadata missing — fall through to Clone with no repos; the
+                    // post-bar cleanup still nukes the workspace root dir.
+                    Err(_) => (name.clone(), workspace::Strategy::Clone, Vec::new()),
+                })
+                .collect();
+            workspace::remove_sessions(&to_remove, verbose);
             for name in &sessions {
-                if let Ok(sess) = session::load(name) {
-                    let strategy = workspace::Strategy::from_str(&sess.strategy)
-                        .unwrap_or(workspace::Strategy::Clone);
-                    workspace::remove_workspace_by_strategy(name, &sess.repos, strategy, verbose);
-                } else {
-                    workspace::remove_workspace(name);
-                }
                 session::remove_dir(name)?;
                 eprintln!("Session '{}' removed.", name);
             }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -43,11 +43,168 @@ impl fmt::Display for Strategy {
     }
 }
 
-/// Remove the workspace directory for a session (clone strategy).
-pub fn remove_workspace(name: &str) {
-    if let Ok(root) = config::box_root() {
-        let dir = root.join("workspaces").join(name);
-        let _ = std::fs::remove_dir_all(&dir);
+/// Remove multiple sessions' workspaces in a single unified progress bar.
+///
+/// Every repo across every session becomes one unit in the same bar — matching
+/// the unified experience of `ensure_workspace_multi*`. For Worktree sessions
+/// each unit runs `git worktree remove --force` + `git branch -D`; for Clone
+/// sessions each unit is a per-repo `fs::remove_dir_all`. After the bar
+/// finishes the now-empty workspace root dir for each session is cleaned up.
+pub fn remove_sessions(sessions: &[(String, Strategy, Vec<String>)], verbose: bool) {
+    let all_repos = crate::repo::list().unwrap_or_default();
+    let root = match config::box_root() {
+        Ok(r) => r,
+        Err(_) => return,
+    };
+
+    enum Unit {
+        Worktree {
+            repo_path: Option<String>,
+            dest: std::path::PathBuf,
+            branch: String,
+        },
+        Clone {
+            dest: std::path::PathBuf,
+        },
+    }
+
+    let mut items: Vec<(String, Unit)> = Vec::new();
+    let mut all_worktree = true;
+    for (name, strategy, repo_names) in sessions {
+        match strategy {
+            Strategy::Worktree => {
+                let branch = format!("box/{}", name);
+                for repo_name in repo_names {
+                    let dest = root.join("workspaces").join(name).join(repo_name);
+                    let repo_path = all_repos
+                        .iter()
+                        .find(|r| r.name == *repo_name)
+                        .map(|r| r.path.clone());
+                    items.push((
+                        format!("{}/{}", name, repo_name),
+                        Unit::Worktree {
+                            repo_path,
+                            dest,
+                            branch: branch.clone(),
+                        },
+                    ));
+                }
+            }
+            Strategy::Clone => {
+                all_worktree = false;
+                for repo_name in repo_names {
+                    let dest = root.join("workspaces").join(name).join(repo_name);
+                    items.push((format!("{}/{}", name, repo_name), Unit::Clone { dest }));
+                }
+            }
+        }
+    }
+
+    if !items.is_empty() {
+        let count = items.len();
+        let noun = if all_worktree { "worktree" } else { "repo" };
+        let label = format!(
+            "Removing {} {}{}",
+            count,
+            noun,
+            if count == 1 { "" } else { "s" }
+        );
+
+        let results = crate::progress::run_parallel_with_progress(
+            &label,
+            items,
+            verbose,
+            false,
+            |_name, unit| match unit {
+                Unit::Worktree {
+                    repo_path,
+                    dest,
+                    branch,
+                } => {
+                    let dest_str = dest.to_string_lossy().to_string();
+                    if let Some(path) = repo_path {
+                        let mut buf = String::new();
+                        let mut success = true;
+                        match Command::new("git")
+                            .args(["-C", &path, "worktree", "remove", "--force", &dest_str])
+                            .output()
+                        {
+                            Ok(o) => {
+                                buf.push_str(&captured_output(&o));
+                                if !o.status.success() {
+                                    success = false;
+                                }
+                            }
+                            Err(e) => {
+                                success = false;
+                                buf.push_str(&format!(
+                                    "failed to run git worktree remove: {}\n",
+                                    e
+                                ));
+                            }
+                        }
+                        match Command::new("git")
+                            .args(["-C", &path, "branch", "-D", &branch])
+                            .output()
+                        {
+                            Ok(o) => {
+                                buf.push_str(&captured_output(&o));
+                                if !o.status.success() {
+                                    success = false;
+                                }
+                            }
+                            Err(e) => {
+                                success = false;
+                                buf.push_str(&format!("failed to run git branch -D: {}\n", e));
+                            }
+                        }
+                        (success, buf)
+                    } else {
+                        match std::fs::remove_dir_all(&dest) {
+                            Ok(()) => (true, String::new()),
+                            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                                (true, String::new())
+                            }
+                            Err(e) => (
+                                false,
+                                format!("failed to remove '{}': {}", dest.display(), e),
+                            ),
+                        }
+                    }
+                }
+                Unit::Clone { dest } => match std::fs::remove_dir_all(&dest) {
+                    Ok(()) => (true, String::new()),
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => (true, String::new()),
+                    Err(e) => (
+                        false,
+                        format!("failed to remove '{}': {}", dest.display(), e),
+                    ),
+                },
+            },
+        );
+
+        if verbose {
+            for result in &results {
+                eprintln!("\x1b[2mremove {}:\x1b[0m", result.name);
+                if !result.output.is_empty() {
+                    eprint!("{}", result.output);
+                }
+                if result.success {
+                    eprintln!("  \x1b[32mok\x1b[0m");
+                } else {
+                    eprintln!("  \x1b[31mfailed\x1b[0m");
+                }
+            }
+        } else {
+            for f in results.iter().filter(|r| !r.success) {
+                eprintln!("  \x1b[1m{}\x1b[0m: {}", f.name, f.output.trim());
+            }
+        }
+    }
+
+    for (name, _, _) in sessions {
+        let session_root = root.join("workspaces").join(name);
+        let _ = std::fs::remove_dir_all(&session_root);
     }
 }
 
@@ -313,119 +470,6 @@ pub fn remove_repo_from_workspace(session_name: &str, repo_name: &str) {
     }
 }
 
-/// Remove worktrees for a session. For each repo, removes the worktree and
-/// deletes the branch. Falls back to rm -rf if repo not in registry.
-/// Repos are removed in parallel for speed.
-pub fn remove_workspace_worktree(name: &str, repo_names: &[String], verbose: bool) {
-    let all_repos = crate::repo::list().unwrap_or_default();
-    let root = match config::box_root() {
-        Ok(r) => r,
-        Err(_) => return,
-    };
-    let branch_name = format!("box/{}", name);
-
-    let items: Vec<_> = repo_names
-        .iter()
-        .map(|repo_name| {
-            let dest = root.join("workspaces").join(name).join(repo_name);
-            let repo_path = all_repos
-                .iter()
-                .find(|r| r.name == *repo_name)
-                .map(|r| r.path.clone());
-            (repo_name.clone(), (repo_path, dest, branch_name.clone()))
-        })
-        .collect();
-
-    if !items.is_empty() {
-        let count = items.len();
-        let label = format!(
-            "Removing {} worktree{}",
-            count,
-            if count == 1 { "" } else { "s" }
-        );
-        let results = crate::progress::run_parallel_with_progress(
-            &label,
-            items,
-            verbose,
-            false,
-            |_name, (repo_path, dest, branch)| {
-                if let Some(path) = repo_path {
-                    let dest_str = dest.to_string_lossy().to_string();
-                    // Remove worktree via git
-                    let wt = Command::new("git")
-                        .args(["-C", &path, "worktree", "remove", "--force", &dest_str])
-                        .output();
-                    // Delete the branch
-                    let br = Command::new("git")
-                        .args(["-C", &path, "branch", "-D", &branch])
-                        .output();
-                    let mut buf = String::new();
-                    let mut success = true;
-                    match wt {
-                        Ok(o) => {
-                            buf.push_str(&captured_output(&o));
-                            if !o.status.success() {
-                                success = false;
-                            }
-                        }
-                        Err(e) => {
-                            success = false;
-                            buf.push_str(&format!("failed to run git worktree remove: {}\n", e));
-                        }
-                    }
-                    match br {
-                        Ok(o) => {
-                            buf.push_str(&captured_output(&o));
-                            if !o.status.success() {
-                                success = false;
-                            }
-                        }
-                        Err(e) => {
-                            success = false;
-                            buf.push_str(&format!("failed to run git branch -D: {}\n", e));
-                        }
-                    }
-                    (success, buf)
-                } else {
-                    // Repo not in registry, fall back to rm -rf
-                    match std::fs::remove_dir_all(&dest) {
-                        Ok(()) => (true, String::new()),
-                        Err(e) => (
-                            false,
-                            format!("failed to remove '{}': {}", dest.display(), e),
-                        ),
-                    }
-                }
-            },
-        );
-
-        if verbose {
-            for result in &results {
-                eprintln!("\x1b[2mremove {}:\x1b[0m", result.name);
-                if !result.output.is_empty() {
-                    eprint!("{}", result.output);
-                }
-                if result.success {
-                    eprintln!("  \x1b[32mok\x1b[0m");
-                } else {
-                    eprintln!("  \x1b[31mfailed\x1b[0m");
-                }
-            }
-        } else {
-            let failures: Vec<_> = results.iter().filter(|r| !r.success).collect();
-            if !failures.is_empty() {
-                for f in &failures {
-                    eprintln!("  \x1b[1m{}\x1b[0m: {}", f.name, f.output.trim());
-                }
-            }
-        }
-    }
-
-    // Remove session workspace root dir
-    let session_root = root.join("workspaces").join(name);
-    let _ = std::fs::remove_dir_all(&session_root);
-}
-
 /// Remove a single repo worktree from a session.
 pub fn remove_repo_from_workspace_worktree(session_name: &str, repo_name: &str) {
     let all_repos = crate::repo::list().unwrap_or_default();
@@ -469,19 +513,6 @@ pub fn ensure_workspace(
     match strategy {
         Strategy::Clone => ensure_workspace_multi(name, repos, fetch, verbose),
         Strategy::Worktree => ensure_workspace_multi_worktree(name, repos, fetch, verbose),
-    }
-}
-
-/// Remove workspace using the given strategy.
-pub fn remove_workspace_by_strategy(
-    name: &str,
-    repo_names: &[String],
-    strategy: Strategy,
-    verbose: bool,
-) {
-    match strategy {
-        Strategy::Clone => remove_workspace(name),
-        Strategy::Worktree => remove_workspace_worktree(name, repo_names, verbose),
     }
 }
 


### PR DESCRIPTION
## Summary
- Multi-session `box rm` (both TUI multi-select and single-session `rm`) now shows **one** unified progress bar covering every repo across every selected session — matching the unified UX introduced for `box new` in #125.
- Previously, removing N sessions rendered N sequential progress bars; now it's a single bar (e.g. "Removing 15 worktrees" for 3 sessions × 5 repos).
- Introduced `workspace::remove_sessions` that flattens per-repo work across sessions into a single `run_parallel_with_progress` call. Replaced the old per-session helpers (`remove_workspace`, `remove_workspace_worktree`, `remove_workspace_by_strategy`).
- Clone-strategy sessions now also split removal per-repo for the same bar; label switches to "Removing N repos" when any Clone session is in the mix (pure-Worktree stays as "Removing N worktrees").

## Test plan
- [x] `cargo fmt` / `cargo clippy -D warnings` clean
- [x] `cargo test` — 120 passing
- [ ] Manually verify `box rm <name>` still renders a single bar for one session with multiple repos
- [ ] Manually verify TUI multi-select across 3+ sessions renders one unified bar
- [ ] Manually verify failures in one session's repo still produce a per-repo error summary after the bar

v0.1.22