### PR TITLE
Add box rebase and expose origin/<branch> refs in bare repos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "box-cli"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "box-cli"
-version = "0.1.22"
+version = "0.1.23"
 edition = "2021"
 description = "Sandboxed git workspaces for development"
 license = "MIT"

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
         box = pkgs.rustPlatform.buildRustPackage {
           pname = "box";
-          version = "0.1.22";
+          version = "0.1.23";
 
           src = ./.;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ use std::path::{Path, PathBuf};
 #[command(
     name = "box",
     about = "Sandboxed git workspaces for development",
-    after_help = "Examples:\n  box                                         # interactive session manager\n  box new my-feature --repo app-a              # create a new session\n  box new my-feature --repo app-a --repo app-b # select specific repos\n  box new my-feature --preset work             # create session from preset\n  box new my-feature --repo app --strategy worktree # use git worktree\n  box edit my-feature                          # add/remove repos in a session\n  box list                                     # list all sessions\n  box remove                                   # interactive session removal\n  box remove my-feature                        # remove a session by name\n  box switch my-feature                        # switch to a session\n  box repo add .                               # register current dir as a repo\n  box repo list                                # list registered repos\n  box repo remove my-app                       # unregister a repo\n  box preset add work --repo app-a --repo app-b # define a preset\n  box preset edit work                          # edit repos in a preset\n  box preset list                               # list presets\n  box preset remove work                        # remove a preset\n  box upgrade                                  # self-update"
+    after_help = "Examples:\n  box                                         # interactive session manager\n  box new my-feature --repo app-a              # create a new session\n  box new my-feature --repo app-a --repo app-b # select specific repos\n  box new my-feature --preset work             # create session from preset\n  box new my-feature --repo app --strategy worktree # use git worktree\n  box edit my-feature                          # add/remove repos in a session\n  box list                                     # list all sessions\n  box remove                                   # interactive session removal\n  box remove my-feature                        # remove a session by name\n  box switch my-feature                        # switch to a session\n  box rebase main                              # fetch origin and rebase HEAD onto main\n  box repo add .                               # register current dir as a repo\n  box repo list                                # list registered repos\n  box repo remove my-app                       # unregister a repo\n  box preset add work --repo app-a --repo app-b # define a preset\n  box preset edit work                          # edit repos in a preset\n  box preset list                               # list presets\n  box preset remove work                        # remove a preset\n  box upgrade                                  # self-update"
 )]
 struct Cli {
     /// Show detailed output
@@ -48,6 +48,11 @@ enum Commands {
     Switch {
         /// Session name
         name: String,
+    },
+    /// Fetch origin and rebase the current branch onto another branch
+    Rebase {
+        /// Branch to rebase onto (e.g. main)
+        branch: String,
     },
     /// Manage registered repos
     Repo {
@@ -174,6 +179,7 @@ fn main() {
         },
         Some(Commands::List(args)) => cmd_list_sessions(&args),
         Some(Commands::Switch { name }) => cmd_cd(&name),
+        Some(Commands::Rebase { branch }) => cmd_rebase(&branch, verbose),
         Some(Commands::Repo { action }) => match action {
             RepoAction::Add { path } => cmd_repo_add(path),
             RepoAction::Remove { name } => cmd_repo_remove(&name),
@@ -612,6 +618,71 @@ fn cmd_cd(name: &str) -> Result<i32> {
     Ok(0)
 }
 
+/// Fetch origin in the bare repo backing the current worktree, then rebase
+/// the worktree's current branch onto `branch`.
+///
+/// Box workspaces share a single bare repo across worktrees, and `git fetch`
+/// from a worktree often refuses to update sibling-worktree branches. This
+/// command routes the fetch through `git::fetch_repo`, which knows how to
+/// exclude checked-out branches with negative refspecs.
+fn cmd_rebase(branch: &str, verbose: bool) -> Result<i32> {
+    let cwd = std::env::current_dir()?;
+    let worktree_root = git::find_root(&cwd)
+        .ok_or_else(|| anyhow::anyhow!("Not in a git repository."))?
+        .to_path_buf();
+    let worktree_root_str = worktree_root.to_string_lossy().to_string();
+
+    let output = std::process::Command::new("git")
+        .args(["-C", &worktree_root_str, "rev-parse", "--git-common-dir"])
+        .output()?;
+    if !output.status.success() {
+        bail!("Failed to determine git common directory.");
+    }
+    let common = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let common_path = if Path::new(&common).is_absolute() {
+        PathBuf::from(common)
+    } else {
+        worktree_root.join(common)
+    };
+    let common_canonical =
+        std::fs::canonicalize(&common_path).unwrap_or_else(|_| common_path.clone());
+    let common_str = common_canonical.to_string_lossy().to_string();
+
+    // Resolve the matching registered repo so fetch_repo's log uses the
+    // user-facing name; if cwd isn't a box-managed worktree we still attempt
+    // the fetch via a synthetic entry pointing at the common dir.
+    let entry = repo::list()
+        .ok()
+        .and_then(|all| {
+            all.into_iter().find(|r| {
+                std::fs::canonicalize(&r.path)
+                    .map(|p| p.to_string_lossy() == common_str)
+                    .unwrap_or(false)
+            })
+        })
+        .unwrap_or_else(|| repo::RepoEntry {
+            name: common_canonical
+                .file_stem()
+                .map(|s| s.to_string_lossy().to_string())
+                .unwrap_or_else(|| "repo".to_string()),
+            path: common_str.clone(),
+        });
+
+    eprintln!("\x1b[2mfetching origin in {}…\x1b[0m", entry.name);
+    let (ok, log) = git::fetch_repo(&entry);
+    if verbose || !ok {
+        eprint!("{}", log);
+    }
+    if !ok {
+        bail!("Fetch failed.");
+    }
+
+    let status = std::process::Command::new("git")
+        .args(["-C", &worktree_root_str, "rebase", branch])
+        .status()?;
+    Ok(if status.success() { 0 } else { 1 })
+}
+
 fn cmd_repo_add(path: Option<String>) -> Result<i32> {
     let path = path.unwrap_or_else(|| ".".to_string());
     repo::add(&path)?;
@@ -787,6 +858,7 @@ _box() {{
                 'switch:Switch to a session'
                 'sw:Switch to a session'
                 'cd:Switch to a session'
+                'rebase:Fetch origin and rebase the current branch'
                 'repo:Manage registered repos'
                 'preset:Manage session presets'
                 'upgrade:Self-update to the latest version'
@@ -825,6 +897,11 @@ _box() {{
                 switch|sw|cd)
                     if (( CURRENT == 2 )); then
                         __box_sessions
+                    fi
+                    ;;
+                rebase)
+                    if (( CURRENT == 2 )); then
+                        _message 'branch (e.g. main)'
                     fi
                     ;;
                 repo)
@@ -906,7 +983,7 @@ fn cmd_config_bash() -> Result<i32> {
     local cur prev words cword
     _init_completion || return
 
-    local subcommands="new edit remove rm list switch sw cd repo preset upgrade config"
+    local subcommands="new edit remove rm list switch sw cd rebase repo preset upgrade config"
     local session_cmds="edit remove rm switch sw cd"
     local __box_root="${{BOX_ROOT:-$HOME/.box}}"
 

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -170,37 +170,68 @@ pub fn add(path: &str) -> Result<()> {
     Ok(())
 }
 
-/// Check and fix fetch refspec on an existing bare repo if missing.
+/// Check and fix fetch refspec on an existing bare repo. Repairs both bare
+/// repos that are missing a refspec entirely (clone --bare default) and bare
+/// repos that only have the legacy single +refs/heads/*:refs/heads/* line
+/// (pre-origin-mapping versions of box).
 fn ensure_fetch_refspec(bare_dir: &str) {
-    let status = Command::new("git")
-        .args(["-C", bare_dir, "config", "remote.origin.fetch"])
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status();
-    let needs_fix = match status {
-        Ok(s) => !s.success(),
-        Err(_) => true,
+    let output = Command::new("git")
+        .args(["-C", bare_dir, "config", "--get-all", "remote.origin.fetch"])
+        .output();
+    let needs_fix = match output {
+        Ok(o) if o.status.success() => {
+            let text = String::from_utf8_lossy(&o.stdout);
+            !text.lines().any(|l| l.trim() == REFSPEC_ORIGIN)
+        }
+        _ => true,
     };
     if needs_fix {
         let _ = configure_fetch_refspec(bare_dir);
     }
 }
 
+/// Refspec that mirrors the remote's branches onto the bare repo's local
+/// heads. Required so `git clone --local <bare>` and `git worktree add` see
+/// up-to-date refs.
+const REFSPEC_HEADS: &str = "+refs/heads/*:refs/heads/*";
+
+/// Refspec that also exposes remote branches under the conventional
+/// `refs/remotes/origin/*` namespace, so `git rebase origin/main` works inside
+/// box workspaces without any special handling.
+const REFSPEC_ORIGIN: &str = "+refs/heads/*:refs/remotes/origin/*";
+
 /// `git clone --bare` does not set `remote.origin.fetch`, so `git fetch` will
-/// download objects but never update local branch refs. This configures the
-/// refspec so that remote branches map directly onto the bare repo's heads.
+/// download objects but never update local refs. We configure two refspecs:
+/// the heads/heads line preserves the bare-as-cache semantics that `box new`
+/// (clone + worktree strategies) relies on, and the heads/remotes line
+/// produces the conventional `origin/<branch>` refs that humans and tools
+/// expect when they `git fetch && git rebase origin/main`.
 fn configure_fetch_refspec(bare_dir: &str) -> Result<()> {
-    let status = Command::new("git")
+    // Clear any pre-existing refspec lines so re-running on a partially
+    // configured bare doesn't leave duplicates.
+    let _ = Command::new("git")
         .args([
             "-C",
             bare_dir,
             "config",
+            "--unset-all",
             "remote.origin.fetch",
-            "+refs/heads/*:refs/heads/*",
         ])
-        .status()?;
-    if !status.success() {
-        bail!("Failed to configure fetch refspec for '{}'.", bare_dir);
+        .status();
+    for refspec in [REFSPEC_HEADS, REFSPEC_ORIGIN] {
+        let status = Command::new("git")
+            .args([
+                "-C",
+                bare_dir,
+                "config",
+                "--add",
+                "remote.origin.fetch",
+                refspec,
+            ])
+            .status()?;
+        if !status.success() {
+            bail!("Failed to configure fetch refspec for '{}'.", bare_dir);
+        }
     }
     Ok(())
 }
@@ -411,12 +442,71 @@ mod tests {
 
             let repos = list().unwrap();
             let output = Command::new("git")
-                .args(["-C", &repos[0].path, "config", "remote.origin.fetch"])
+                .args([
+                    "-C",
+                    &repos[0].path,
+                    "config",
+                    "--get-all",
+                    "remote.origin.fetch",
+                ])
                 .output()
                 .unwrap();
             assert!(output.status.success());
-            let refspec = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            assert_eq!(refspec, "+refs/heads/*:refs/heads/*");
+            let lines: Vec<String> = String::from_utf8_lossy(&output.stdout)
+                .lines()
+                .map(|l| l.trim().to_string())
+                .collect();
+            assert_eq!(
+                lines,
+                vec![
+                    "+refs/heads/*:refs/heads/*".to_string(),
+                    "+refs/heads/*:refs/remotes/origin/*".to_string(),
+                ]
+            );
+        });
+    }
+
+    #[test]
+    fn test_ensure_fetch_refspec_migrates_legacy_single_line() {
+        with_temp_home(|home| {
+            let repo = make_git_repo(home, "legacy");
+            add(repo.to_str().unwrap()).unwrap();
+
+            // Simulate a bare cloned by an older box version that only knew
+            // about the heads/heads refspec.
+            let repos = list().unwrap();
+            let bare = &repos[0].path;
+            let s = Command::new("git")
+                .args(["-C", bare, "config", "--unset-all", "remote.origin.fetch"])
+                .status()
+                .unwrap();
+            assert!(s.success());
+            let s = Command::new("git")
+                .args([
+                    "-C",
+                    bare,
+                    "config",
+                    "--add",
+                    "remote.origin.fetch",
+                    "+refs/heads/*:refs/heads/*",
+                ])
+                .status()
+                .unwrap();
+            assert!(s.success());
+
+            // list() invokes ensure_fetch_refspec on each bare; the second
+            // pass should re-add the origin/* line.
+            let _ = list().unwrap();
+
+            let output = Command::new("git")
+                .args(["-C", bare, "config", "--get-all", "remote.origin.fetch"])
+                .output()
+                .unwrap();
+            let lines: Vec<String> = String::from_utf8_lossy(&output.stdout)
+                .lines()
+                .map(|l| l.trim().to_string())
+                .collect();
+            assert!(lines.contains(&"+refs/heads/*:refs/remotes/origin/*".to_string()));
         });
     }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -43,6 +43,7 @@ pub fn sessions_dir() -> Result<PathBuf> {
 
 const RESERVED_NAMES: &[&str] = &[
     "new", "remove", "edit", "update", "upgrade", "path", "config", "list", "ls", "repo", "preset",
+    "rebase",
 ];
 
 /// Normalize a session name by replacing any non-alphanumeric character with `-`


### PR DESCRIPTION
## Summary
- Bare clones now configure a second fetch refspec (`+refs/heads/*:refs/remotes/origin/*`) alongside the existing heads/heads line, so `git rebase origin/main` and other conventional commands work inside box workspaces. Existing bare repos are migrated on the next `repo::list()` pass.
- New `box rebase <branch>` subcommand: resolves the worktree's bare via `git rev-parse --git-common-dir`, fetches through `git::fetch_repo` (which already excludes checked-out worktree branches with negative refspecs), then runs `git rebase <branch>` in the worktree.
- `rebase` added to reserved session names; zsh + bash completions and after-help examples updated.

## Test plan
- [x] `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (121 passed)
- [x] New unit test covers legacy single-line refspec → dual-line migration via `ensure_fetch_refspec`
- [x] Existing `test_bare_clone_has_fetch_refspec` updated for the dual-line form
- [x] Manual: `box repo list` migrates an in-place bare; `git rev-parse origin/main` resolves afterwards
- [x] Manual: `box rebase main` from a worktree fetches without "refusing to fetch into branch" errors and invokes `git rebase main` in the worktree

v0.1.23

🤖 Generated with [Claude Code](https://claude.com/claude-code)