### PR TITLE
Fix --force-with-lease for box-created session branches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "box-cli"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "box-cli"
-version = "0.1.24"
+version = "0.1.25"
 edition = "2021"
 description = "Sandboxed git workspaces for development"
 license = "MIT"

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
         box = pkgs.rustPlatform.buildRustPackage {
           pname = "box";
-          version = "0.1.24";
+          version = "0.1.25";
 
           src = ./.;
 

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -112,6 +112,8 @@ pub fn list() -> Result<Vec<RepoEntry>> {
                 let path_str = path.to_string_lossy().to_string();
                 // Ensure fetch refspec is set (repairs bare repos created before this fix)
                 ensure_fetch_refspec(&path_str);
+                // Fix box/* session branches that inherited main's upstream
+                repair_box_branch_upstreams(&path_str);
                 entries.push(RepoEntry {
                     name: name.to_string(),
                     path: path_str,
@@ -170,23 +172,90 @@ pub fn add(path: &str) -> Result<()> {
     Ok(())
 }
 
-/// Check and fix fetch refspec on an existing bare repo. Repairs both bare
-/// repos that are missing a refspec entirely (clone --bare default) and bare
-/// repos that only have the legacy single +refs/heads/*:refs/heads/* line
-/// (pre-origin-mapping versions of box).
+/// Check and fix fetch refspec and `push.autoSetupRemote` on an existing bare
+/// repo. Repairs bares that are missing a refspec entirely (clone --bare
+/// default), bares that only have the legacy single +refs/heads/*:refs/heads/*
+/// line (pre-origin-mapping versions of box), and bares created before
+/// `push.autoSetupRemote` was added.
 fn ensure_fetch_refspec(bare_dir: &str) {
-    let output = Command::new("git")
+    let needs_refspec = match Command::new("git")
         .args(["-C", bare_dir, "config", "--get-all", "remote.origin.fetch"])
-        .output();
-    let needs_fix = match output {
+        .output()
+    {
         Ok(o) if o.status.success() => {
             let text = String::from_utf8_lossy(&o.stdout);
             !text.lines().any(|l| l.trim() == REFSPEC_ORIGIN)
         }
         _ => true,
     };
-    if needs_fix {
+    let needs_autosetup = match Command::new("git")
+        .args(["-C", bare_dir, "config", "--get", "push.autoSetupRemote"])
+        .output()
+    {
+        Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).trim() != "true",
+        _ => true,
+    };
+    if needs_refspec || needs_autosetup {
         let _ = configure_fetch_refspec(bare_dir);
+    }
+}
+
+/// Repair `branch.box/<session>.merge` entries that point at the start-point's
+/// upstream (typically `refs/heads/main`) instead of the session branch's own
+/// ref. Stock `git worktree add -b box/<session>` from a bare carries main's
+/// tracking forward, which silently breaks `git push` (default `simple` mode
+/// refuses on name mismatch) and `git push --force-with-lease` (the lease
+/// check then targets `origin/main`'s SHA). New sessions get this right via
+/// `workspace::set_self_upstream`; this is the migration for sessions created
+/// before that fix.
+fn repair_box_branch_upstreams(bare_dir: &str) {
+    let output = Command::new("git")
+        .args([
+            "-C",
+            bare_dir,
+            "config",
+            "--get-regexp",
+            r"^branch\.box/.+\.merge$",
+        ])
+        .output();
+    let Ok(output) = output else { return };
+    if !output.status.success() {
+        // Exit 1 means no matching keys — nothing to repair.
+        return;
+    }
+    let text = String::from_utf8_lossy(&output.stdout).to_string();
+    for line in text.lines() {
+        let Some((key, value)) = line.split_once(' ') else {
+            continue;
+        };
+        let Some(branch) = key
+            .strip_prefix("branch.")
+            .and_then(|s| s.strip_suffix(".merge"))
+        else {
+            continue;
+        };
+        let expected = format!("refs/heads/{}", branch);
+        if value == expected {
+            continue;
+        }
+        let _ = Command::new("git")
+            .args([
+                "-C",
+                bare_dir,
+                "config",
+                &format!("branch.{}.merge", branch),
+                &expected,
+            ])
+            .output();
+        let _ = Command::new("git")
+            .args([
+                "-C",
+                bare_dir,
+                "config",
+                &format!("branch.{}.remote", branch),
+                "origin",
+            ])
+            .output();
     }
 }
 
@@ -206,6 +275,11 @@ const REFSPEC_ORIGIN: &str = "+refs/heads/*:refs/remotes/origin/*";
 /// (clone + worktree strategies) relies on, and the heads/remotes line
 /// produces the conventional `origin/<branch>` refs that humans and tools
 /// expect when they `git fetch && git rebase origin/main`.
+///
+/// We also set `push.autoSetupRemote = true` so the first `git push` of a
+/// branch box created locally records its upstream — without that,
+/// `refs/remotes/origin/<branch>` is never written and `git push
+/// --force-with-lease` fails with "no such ref".
 fn configure_fetch_refspec(bare_dir: &str) -> Result<()> {
     // Clear any pre-existing refspec lines so re-running on a partially
     // configured bare doesn't leave duplicates.
@@ -232,6 +306,12 @@ fn configure_fetch_refspec(bare_dir: &str) -> Result<()> {
         if !status.success() {
             bail!("Failed to configure fetch refspec for '{}'.", bare_dir);
         }
+    }
+    let status = Command::new("git")
+        .args(["-C", bare_dir, "config", "push.autoSetupRemote", "true"])
+        .status()?;
+    if !status.success() {
+        bail!("Failed to set push.autoSetupRemote for '{}'.", bare_dir);
     }
     Ok(())
 }
@@ -463,6 +543,46 @@ mod tests {
                     "+refs/heads/*:refs/remotes/origin/*".to_string(),
                 ]
             );
+
+            let auto = Command::new("git")
+                .args([
+                    "-C",
+                    &repos[0].path,
+                    "config",
+                    "--get",
+                    "push.autoSetupRemote",
+                ])
+                .output()
+                .unwrap();
+            assert!(auto.status.success());
+            assert_eq!(String::from_utf8_lossy(&auto.stdout).trim(), "true");
+        });
+    }
+
+    #[test]
+    fn test_ensure_fetch_refspec_sets_missing_push_autosetup() {
+        with_temp_home(|home| {
+            let repo = make_git_repo(home, "needs-autosetup");
+            add(repo.to_str().unwrap()).unwrap();
+
+            // Simulate a bare from a box version that configured the fetch
+            // refspec but not push.autoSetupRemote.
+            let repos = list().unwrap();
+            let bare = &repos[0].path;
+            let s = Command::new("git")
+                .args(["-C", bare, "config", "--unset", "push.autoSetupRemote"])
+                .status()
+                .unwrap();
+            assert!(s.success());
+
+            let _ = list().unwrap();
+
+            let auto = Command::new("git")
+                .args(["-C", bare, "config", "--get", "push.autoSetupRemote"])
+                .output()
+                .unwrap();
+            assert!(auto.status.success());
+            assert_eq!(String::from_utf8_lossy(&auto.stdout).trim(), "true");
         });
     }
 
@@ -507,6 +627,64 @@ mod tests {
                 .map(|l| l.trim().to_string())
                 .collect();
             assert!(lines.contains(&"+refs/heads/*:refs/remotes/origin/*".to_string()));
+        });
+    }
+
+    #[test]
+    fn test_list_repairs_misconfigured_box_branch_upstreams() {
+        with_temp_home(|home| {
+            let repo = make_git_repo(home, "with-sessions");
+            add(repo.to_str().unwrap()).unwrap();
+            let bare = list().unwrap()[0].path.clone();
+
+            // Simulate two session branches created by an older box version:
+            // one misconfigured (tracks main), one configured by hand to track
+            // a sibling branch (we leave that one alone — only fix `box/*`
+            // entries that point at the wrong place).
+            for (branch, merge) in [
+                ("box/foo", "refs/heads/main"),
+                ("box/bar", "refs/heads/box/bar"), // already correct
+                ("feature/baz", "refs/heads/main"), // not a box branch — ignore
+            ] {
+                let s = Command::new("git")
+                    .args([
+                        "-C",
+                        &bare,
+                        "config",
+                        &format!("branch.{}.remote", branch),
+                        "origin",
+                    ])
+                    .status()
+                    .unwrap();
+                assert!(s.success());
+                let s = Command::new("git")
+                    .args([
+                        "-C",
+                        &bare,
+                        "config",
+                        &format!("branch.{}.merge", branch),
+                        merge,
+                    ])
+                    .status()
+                    .unwrap();
+                assert!(s.success());
+            }
+
+            // list() invokes repair_box_branch_upstreams on each bare.
+            let _ = list().unwrap();
+
+            let value = |key: &str| -> String {
+                let out = Command::new("git")
+                    .args(["-C", &bare, "config", "--get", key])
+                    .output()
+                    .unwrap();
+                String::from_utf8_lossy(&out.stdout).trim().to_string()
+            };
+
+            assert_eq!(value("branch.box/foo.merge"), "refs/heads/box/foo");
+            assert_eq!(value("branch.box/bar.merge"), "refs/heads/box/bar");
+            // feature/* untouched — only box/* sessions are box's responsibility.
+            assert_eq!(value("branch.feature/baz.merge"), "refs/heads/main");
         });
     }
 

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -401,10 +401,10 @@ pub fn ensure_workspace_multi_worktree(
                     .env("GIT_TERMINAL_PROMPT", "0")
                     .output();
 
-                match result {
+                let success = match result {
                     Ok(output) if output.status.success() => {
                         buf.push_str(&captured_output(&output));
-                        (true, buf)
+                        true
                     }
                     Ok(first_output) => {
                         buf.push_str(&captured_output(&first_output));
@@ -416,19 +416,24 @@ pub fn ensure_workspace_multi_worktree(
                         {
                             Ok(output2) => {
                                 buf.push_str(&captured_output(&output2));
-                                (output2.status.success(), buf)
+                                output2.status.success()
                             }
                             Err(e) => {
                                 buf.push_str(&format!("failed to run git: {}\n", e));
-                                (false, buf)
+                                false
                             }
                         }
                     }
                     Err(e) => {
                         buf.push_str(&format!("failed to run git: {}\n", e));
-                        (false, buf)
+                        false
                     }
+                };
+
+                if success {
+                    set_self_upstream(&dest_str, &branch);
                 }
+                (success, buf)
             },
         );
 
@@ -538,6 +543,35 @@ fn captured_output(output: &std::process::Output) -> String {
     buf
 }
 
+/// Configure the worktree's branch to track `origin/<branch>` (a same-name
+/// upstream) rather than inheriting the start-point's tracking. `git worktree
+/// add -b` defaults to copying the start-point's upstream config — for a
+/// session branch like `box/foo` started from `main`, that leaves the branch
+/// tracking `origin/main`, which silently breaks `git push` (`push.default =
+/// simple` refuses on name mismatch) and `git push --force-with-lease` (the
+/// lease check then targets `origin/main`'s SHA, not the session branch's).
+fn set_self_upstream(worktree_dir: &str, branch: &str) {
+    let merge_ref = format!("refs/heads/{}", branch);
+    let _ = Command::new("git")
+        .args([
+            "-C",
+            worktree_dir,
+            "config",
+            &format!("branch.{}.remote", branch),
+            "origin",
+        ])
+        .output();
+    let _ = Command::new("git")
+        .args([
+            "-C",
+            worktree_dir,
+            "config",
+            &format!("branch.{}.merge", branch),
+            &merge_ref,
+        ])
+        .output();
+}
+
 /// Re-point origin remote from local path to the real remote URL.
 fn repoint_origin(project_dir: &str, clone_dir: &str) {
     if let Ok(output) = Command::new("git")
@@ -552,5 +586,121 @@ fn repoint_origin(project_dir: &str, clone_dir: &str) {
                     .output();
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    fn run_git(args: &[&str]) {
+        let s = Command::new("git").args(args).status().unwrap();
+        assert!(s.success(), "git {:?} failed", args);
+    }
+
+    fn config_value(dir: &str, key: &str) -> String {
+        let out = Command::new("git")
+            .args(["-C", dir, "config", "--get", key])
+            .output()
+            .unwrap();
+        assert!(out.status.success(), "git config --get {} failed", key);
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    }
+
+    #[test]
+    fn test_worktree_branch_tracks_itself_not_source_branch() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let bare = home.join("repo.git");
+        let bare_str = bare.to_str().unwrap();
+
+        // Build a "remote" with a main branch, then clone --bare to mimic
+        // box's repo setup.
+        let remote = home.join("remote.git");
+        run_git(&[
+            "-c",
+            "init.defaultBranch=main",
+            "init",
+            "--bare",
+            remote.to_str().unwrap(),
+        ]);
+        let src = home.join("src");
+        run_git(&[
+            "-c",
+            "init.defaultBranch=main",
+            "clone",
+            remote.to_str().unwrap(),
+            src.to_str().unwrap(),
+        ]);
+        let src_str = src.to_str().unwrap();
+        run_git(&[
+            "-C",
+            src_str,
+            "-c",
+            "user.email=t@t",
+            "-c",
+            "user.name=t",
+            "commit",
+            "--allow-empty",
+            "-m",
+            "init",
+        ]);
+        run_git(&["-C", src_str, "push", "-q", "origin", "main"]);
+        run_git(&["clone", "--bare", remote.to_str().unwrap(), bare_str]);
+
+        // Mirror box's bare setup: BOTH the heads/heads refspec (which makes
+        // `refs/heads/*` act as the remote-tracking namespace and is what
+        // triggers git's `worktree add -b` to copy upstream forward) and the
+        // origin/* refspec.
+        run_git(&[
+            "-C",
+            bare_str,
+            "config",
+            "remote.origin.fetch",
+            "+refs/heads/*:refs/heads/*",
+        ]);
+        run_git(&[
+            "-C",
+            bare_str,
+            "config",
+            "--add",
+            "remote.origin.fetch",
+            "+refs/heads/*:refs/remotes/origin/*",
+        ]);
+        run_git(&["-C", bare_str, "fetch", "-q", "origin"]);
+
+        // Reproduce git's stock behavior: `git worktree add -b` from a bare
+        // copies main's upstream config to the new branch.
+        let wt = home.join("wt");
+        run_git(&[
+            "-C",
+            bare_str,
+            "worktree",
+            "add",
+            wt.to_str().unwrap(),
+            "-b",
+            "box/foo",
+        ]);
+        assert_eq!(
+            config_value(wt.to_str().unwrap(), "branch.box/foo.merge"),
+            "refs/heads/main",
+            "precondition: stock git misconfigures upstream"
+        );
+
+        // After our fix runs, the branch should track itself.
+        set_self_upstream(wt.to_str().unwrap(), "box/foo");
+        assert_eq!(
+            config_value(wt.to_str().unwrap(), "branch.box/foo.merge"),
+            "refs/heads/box/foo"
+        );
+        assert_eq!(
+            config_value(wt.to_str().unwrap(), "branch.box/foo.remote"),
+            "origin"
+        );
+
+        // Sanity: the worktree's git common dir is the bare, so the config
+        // wrote to the bare, not the worktree-only config.
+        assert!(Path::new(bare_str).join("config").exists());
     }
 }


### PR DESCRIPTION
## Summary
- `git worktree add -b box/<session>` from a bare repo silently gave new branches the wrong upstream (`refs/heads/main` instead of `refs/heads/box/<session>`), which broke `git push` (default `simple` refuses on name mismatch) and `git push --force-with-lease` (the lease check then targets `origin/main`'s SHA).
- `workspace.rs::set_self_upstream` rewrites the upstream right after `worktree add -b` succeeds, so freshly created sessions track themselves.
- `repo.rs::repair_box_branch_upstreams` migrates already-misconfigured `branch.box/*.merge` entries on every `repo list` invocation, and `configure_fetch_refspec` now also sets `push.autoSetupRemote = true` on bares.

## Test plan
- [x] `cargo test` — 127 passing, including a new test that reproduces stock git's misconfiguration before applying the fix.
- [x] Verified end-to-end on the live `~/.box/repos/box.git`: deliberately broke `branch.box/box-ref.merge` to `refs/heads/main`, ran `cargo run -- repo list`, confirmed the migration restored it to `refs/heads/box/box-ref`.
- [ ] After merge, `git push --force-with-lease` from inside any new `box new` session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)