### PR TITLE
Replace tmux/zellij rename with BOX_POST_SWITCH_HOOK (v0.1.31)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "box-cli"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "box-cli"
-version = "0.1.30"
+version = "0.1.31"
 edition = "2021"
 description = "Sandboxed git workspaces for development"
 license = "MIT"

--- a/README.ja.md
+++ b/README.ja.md
@@ -149,7 +149,7 @@ box cd my-feature               # エイリアス
 box sw my-feature               # エイリアス
 ```
 
-シェル連携を有効にしている場合（`eval "$(box config zsh)"`）、`box switch`で作業ディレクトリが切り替わり、現在のzellij/tmuxタブがセッション名にリネームされます。未設定の場合はワークスペースのパスが標準出力に表示されます。
+シェル連携を有効にしている場合（`eval "$(box config zsh)"`）、`box switch`で作業ディレクトリが切り替わります。`BOX_POST_SWITCH_HOOK`を設定しておくと、セッション名を引数にそのフックも実行されます（[シェル連携](#シェル連携)参照）。シェル連携未設定の場合はワークスペースのパスが標準出力に表示されます。
 
 ### 現在のブランチをrebase
 
@@ -226,6 +226,7 @@ box new my-feature --preset work                     # 利用
 | `BOX_STRATEGY` | デフォルトのワークスペース戦略（`worktree`または`clone`）。`--strategy`で上書き可能 |
 | `BOX_VERBOSE` | 設定すると`--verbose`と同等 |
 | `BOX_ROOT` | boxのデータディレクトリを上書き（デフォルト`~/.box`）。シェル補完が参照 |
+| `BOX_POST_SWITCH_HOOK` | `box switch` / `box new`後に実行されるシェルスニペット。セッション名は`$BOX_SESSION_NAME`で参照可能。[シェル連携](#シェル連携)参照 |
 
 ## シェル連携
 
@@ -241,7 +242,27 @@ eval "$(box config bash)"
 
 - セッション・リポジトリ・プリセットのタブ補完
 - `box switch` / `box new`で作業ディレクトリを切り替える`box`シェル関数
-- セッション切り替えや作成時にzellij/tmuxのタブをセッション名に自動リネーム
+- セッションへ入った後に実行される`BOX_POST_SWITCH_HOOK`（セッション名は`$BOX_SESSION_NAME`で参照可能）
+
+### ポストスイッチフック
+
+セッション切り替え・作成時に実行したいシェルスニペットを`BOX_POST_SWITCH_HOOK`に設定します（`box new`と`box switch`の両方で発火）。よく使う例：
+
+```bash
+# tmux — 現在のウィンドウをリネーム
+export BOX_POST_SWITCH_HOOK='tmux rename-window "$BOX_SESSION_NAME"'
+
+# zellij — 現在のタブをリネーム
+export BOX_POST_SWITCH_HOOK='zellij action rename-tab "$BOX_SESSION_NAME"'
+
+# kitty — タブタイトルを設定
+export BOX_POST_SWITCH_HOOK='kitty @ set-tab-title "$BOX_SESSION_NAME"'
+
+# 汎用 OSC 2 — 端末のウィンドウ／タブタイトルを設定
+export BOX_POST_SWITCH_HOOK='printf "\033]2;%s\007" "$BOX_SESSION_NAME"'
+```
+
+スニペットは`eval`で現在のシェル内で実行されるため、`$TMUX`や`$ZELLIJ`などの環境変数も分岐に使えます。
 
 ## 仕組み
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ box cd my-feature               # Alias
 box sw my-feature               # Alias
 ```
 
-With shell integration enabled (`eval "$(box config zsh)"`), `box switch` changes your working directory and renames the current zellij/tmux tab to the session name. Without it, the workspace path is printed to stdout.
+With shell integration enabled (`eval "$(box config zsh)"`), `box switch` changes your working directory. If you set `BOX_POST_SWITCH_HOOK`, it also runs that hook with the session name (see [Shell Integration](#shell-integration)). Without shell integration, the workspace path is printed to stdout.
 
 ### Rebase the current branch
 
@@ -226,6 +226,7 @@ box new my-feature --preset work                     # use it
 | `BOX_STRATEGY` | Default workspace strategy (`worktree` or `clone`). Overridden by `--strategy` |
 | `BOX_VERBOSE` | When set, equivalent to `--verbose` |
 | `BOX_ROOT` | Override the box data directory (default `~/.box`). Read by the shell completions |
+| `BOX_POST_SWITCH_HOOK` | Shell snippet run after `box switch` / `box new`. The session name is available as `$BOX_SESSION_NAME`. See [Shell Integration](#shell-integration) |
 
 ## Shell Integration
 
@@ -241,7 +242,27 @@ This provides:
 
 - Tab completion for sessions, repos, and presets
 - A `box` shell function so `box switch` / `box new` change your working directory
-- Automatic zellij/tmux tab renaming to the session name when switching into or creating a session
+- A `BOX_POST_SWITCH_HOOK` that runs after switching into or creating a session, with the session name in `$BOX_SESSION_NAME`
+
+### Post-switch hook
+
+Set `BOX_POST_SWITCH_HOOK` to any shell snippet you want to run when a session is entered (fires on both `box new` and `box switch`). Common choices:
+
+```bash
+# tmux — rename the current window
+export BOX_POST_SWITCH_HOOK='tmux rename-window "$BOX_SESSION_NAME"'
+
+# zellij — rename the current tab
+export BOX_POST_SWITCH_HOOK='zellij action rename-tab "$BOX_SESSION_NAME"'
+
+# kitty — set the tab title
+export BOX_POST_SWITCH_HOOK='kitty @ set-tab-title "$BOX_SESSION_NAME"'
+
+# Generic OSC 2 — set the terminal window/tab title
+export BOX_POST_SWITCH_HOOK='printf "\033]2;%s\007" "$BOX_SESSION_NAME"'
+```
+
+The snippet runs in the current shell via `eval`, so `$TMUX`, `$ZELLIJ`, and other environment variables are available for branching.
 
 ## How It Works
 

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
         box = pkgs.rustPlatform.buildRustPackage {
           pname = "box";
-          version = "0.1.30";
+          version = "0.1.31";
 
           src = ./.;
 

--- a/src/completions/box.bash
+++ b/src/completions/box.bash
@@ -141,25 +141,21 @@ _box() {
 complete -F _box box
 
 box() {
-    local __box_cd_file __box_rename_file
+    local __box_cd_file __box_post_switch_file
     __box_cd_file=$(mktemp "/tmp/.box-cd.XXXXXX")
-    __box_rename_file=$(mktemp "/tmp/.box-rename.XXXXXX")
-    BOX_CD_FILE="$__box_cd_file" BOX_RENAME_FILE="$__box_rename_file" command box "$@"
+    __box_post_switch_file=$(mktemp "/tmp/.box-post-switch.XXXXXX")
+    BOX_CD_FILE="$__box_cd_file" BOX_POST_SWITCH_FILE="$__box_post_switch_file" command box "$@"
     local __box_exit=$?
     if [[ -s "$__box_cd_file" ]]; then
         local __box_dir
         __box_dir=$(<"$__box_cd_file")
         cd "$__box_dir"
     fi
-    if [[ -s "$__box_rename_file" ]]; then
+    if [[ -s "$__box_post_switch_file" ]] && [[ -n "$BOX_POST_SWITCH_HOOK" ]]; then
         local __box_name
-        __box_name=$(<"$__box_rename_file")
-        if [[ -n "$ZELLIJ" ]]; then
-            command zellij action rename-tab "$__box_name" 2>/dev/null
-        elif [[ -n "$TMUX" ]]; then
-            command tmux rename-window -t "$TMUX_PANE" "$__box_name" 2>/dev/null
-        fi
+        __box_name=$(<"$__box_post_switch_file")
+        BOX_SESSION_NAME="$__box_name" eval "$BOX_POST_SWITCH_HOOK"
     fi
-    rm -f "$__box_cd_file" "$__box_rename_file"
+    rm -f "$__box_cd_file" "$__box_post_switch_file"
     return $__box_exit
 }

--- a/src/completions/box.zsh
+++ b/src/completions/box.zsh
@@ -168,25 +168,21 @@ _box() {
 compdef _box box
 
 box() {
-    local __box_cd_file __box_rename_file
+    local __box_cd_file __box_post_switch_file
     __box_cd_file=$(mktemp "/tmp/.box-cd.XXXXXX")
-    __box_rename_file=$(mktemp "/tmp/.box-rename.XXXXXX")
-    BOX_CD_FILE="$__box_cd_file" BOX_RENAME_FILE="$__box_rename_file" command box "$@"
+    __box_post_switch_file=$(mktemp "/tmp/.box-post-switch.XXXXXX")
+    BOX_CD_FILE="$__box_cd_file" BOX_POST_SWITCH_FILE="$__box_post_switch_file" command box "$@"
     local __box_exit=$?
     if [[ -s "$__box_cd_file" ]]; then
         local __box_dir
         __box_dir=$(<"$__box_cd_file")
         cd "$__box_dir"
     fi
-    if [[ -s "$__box_rename_file" ]]; then
+    if [[ -s "$__box_post_switch_file" ]] && [[ -n "$BOX_POST_SWITCH_HOOK" ]]; then
         local __box_name
-        __box_name=$(<"$__box_rename_file")
-        if [[ -n "$ZELLIJ" ]]; then
-            command zellij action rename-tab "$__box_name" 2>/dev/null
-        elif [[ -n "$TMUX" ]]; then
-            command tmux rename-window -t "$TMUX_PANE" "$__box_name" 2>/dev/null
-        fi
+        __box_name=$(<"$__box_post_switch_file")
+        BOX_SESSION_NAME="$__box_name" eval "$BOX_POST_SWITCH_HOOK"
     fi
-    rm -f "$__box_cd_file" "$__box_rename_file"
+    rm -f "$__box_cd_file" "$__box_post_switch_file"
     return $__box_exit
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -238,9 +238,9 @@ fn output_cd_path(path: &str) {
     }
 }
 
-fn rename_terminal_tab(name: &str) {
-    if let Ok(rename_file) = std::env::var("BOX_RENAME_FILE") {
-        let _ = fs::write(rename_file, name);
+fn signal_post_switch_hook(name: &str) {
+    if let Ok(hook_file) = std::env::var("BOX_POST_SWITCH_FILE") {
+        let _ = fs::write(hook_file, name);
     }
 }
 
@@ -510,7 +510,7 @@ fn cmd_create(
     } else {
         output_cd_path(&workspace_path);
     }
-    rename_terminal_tab(name);
+    signal_post_switch_hook(name);
 
     Ok(0)
 }
@@ -717,7 +717,7 @@ fn cmd_cd(name: &str) -> Result<i32> {
     }
     let path = resolve_workspace_path(name)?;
     output_cd_path(&path.to_string_lossy());
-    rename_terminal_tab(name);
+    signal_post_switch_hook(name);
     Ok(0)
 }
 


### PR DESCRIPTION
## Summary

- Replace the hardcoded tmux/zellij tab-rename logic in the shell wrapper with a generic `BOX_POST_SWITCH_HOOK` env var, so any terminal multiplexer (kitty, WezTerm, OSC 2, …) can be wired in.
- The `box` binary now writes the session name to `$BOX_POST_SWITCH_FILE` (renamed from `BOX_RENAME_FILE`); the shell wrapper `eval`s `$BOX_POST_SWITCH_HOOK` with `$BOX_SESSION_NAME` set. Fires on both `box new` and `box switch`/`cd`/`sw`.
- Bump version 0.1.30 → 0.1.31 (`Cargo.toml`, `flake.nix`).

### Breaking change

Users on 0.1.30 who relied on automatic tmux/zellij tab renaming must now opt in by exporting the hook in their shell rc:

```sh
# tmux
export BOX_POST_SWITCH_HOOK='tmux rename-window "$BOX_SESSION_NAME"'
# zellij
export BOX_POST_SWITCH_HOOK='zellij action rename-tab "$BOX_SESSION_NAME"'
```

README (EN + JA) documents tmux / zellij / kitty / OSC 2 example snippets.

## Code Review

Full diff reviewed against correctness, error handling, security, conventions, dead code:

- **Correctness** — hook fires in both `cmd_create` and `cmd_cd`, matching the previous rename behavior.
- **Security** — `eval` is used on `BOX_POST_SWITCH_HOOK`, but the value is user-owned (same trust as `.bashrc`). The injected `BOX_SESSION_NAME` is safe because `session::normalize_name` restricts names to `[A-Za-z0-9-]` only.
- **Conventions** — both `box.zsh` and `box.bash` updated per `CLAUDE.md`.
- **Dead code** — no `RENAME` / `rename_terminal_tab` / tmux / zellij residue remains in the codebase.

No issues found that required additional fixes beyond the implementation itself.

### Review Checklist
- [x] Formatter (`cargo fmt`) — passed
- [x] Linter (`cargo clippy --all-targets -- -D warnings`) — passed, 0 warnings
- [x] Tests (`cargo test`) — 131 passed
- [x] Full diff reviewed against: correctness, error handling, performance, security, conventions, tests, dead code

## Test plan

1. Build: `cargo build`
2. Install completions: `eval "$(box config zsh)"` (or bash)
3. Without `BOX_POST_SWITCH_HOOK` set → `box new foo` and `box switch foo` should NOT touch the tab title.
4. With `export BOX_POST_SWITCH_HOOK='printf "\033]2;%s\007" "$BOX_SESSION_NAME"'` → tab/window title should update to the session name on both `new` and `switch`.
5. In tmux, set `export BOX_POST_SWITCH_HOOK='tmux rename-window "$BOX_SESSION_NAME"'` → window should rename on switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)