### PR TITLE
git: prune deleted upstream branches on box new fetch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "box-cli"
-version = "0.1.31"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "box-cli"
-version = "0.1.31"
+version = "0.2.0"
 edition = "2021"
 description = "Sandboxed git workspaces for development"
 license = "MIT"

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
         box = pkgs.rustPlatform.buildRustPackage {
           pname = "box";
-          version = "0.1.31";
+          version = "0.2.0";
 
           src = ./.;
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -20,6 +20,10 @@ pub fn find_root(dir: &Path) -> Option<&Path> {
 
 /// Fetch all refs for a bare repo, capturing output.
 ///
+/// Uses `--prune` so local heads whose upstream counterpart was deleted are
+/// removed, keeping the bare repo in sync with `origin`. Branches checked out
+/// in a worktree are excluded from the refspec, so they are never pruned.
+///
 /// When worktrees have branches checked out, git refuses to update those refs
 /// via fetch. We detect checked-out branches and exclude them with negative
 /// refspecs. If git still refuses (e.g. a worktree admin entry we missed),
@@ -35,6 +39,7 @@ pub fn fetch_repo(entry: &crate::repo::RepoEntry) -> (bool, String) {
             "-C".into(),
             entry.path.clone(),
             "fetch".into(),
+            "--prune".into(),
             "origin".into(),
             "+refs/heads/*:refs/heads/*".into(),
         ];


### PR DESCRIPTION
## Summary
- Add `--prune` to the `fetch_repo` git fetch used by `box new`, so local heads whose upstream counterpart was deleted on `origin` are removed.
- Branches checked out in a worktree remain excluded via negative refspecs (`^refs/heads/<branch>`), so in-use session branches are never pruned.

## Code Review
Single-line behavioral change plus a doc-comment update. Reviewed full `fetch_repo` context:
- **Correctness** — `--prune` scoped by the `+refs/heads/*:refs/heads/*` refspec; negative refspecs for checked-out branches also exclude them from pruning, protecting active worktrees.
- **Error handling** — Retry loop and failure capture unchanged.
- **Conventions** — No CLI flags added, so inline zsh/bash completions need no change.

### Review Checklist
- [x] Formatter — passed (`cargo fmt`)
- [x] Linter / static checks — passed (`cargo clippy`, no warnings)
- [x] Tests — passed (131 passed, 0 failed)
- [x] Full diff reviewed against: correctness, error handling, performance, security, conventions, tests, dead code

## Test plan
- `cargo test`
- Manual: delete a branch on a remote, run `box new`, confirm the stale local head no longer appears in the bare repo while checked-out worktree branches are retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)