### PR TITLE
repo: accept git remote URL in box repo add

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "box-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "box-cli"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Sandboxed git workspaces for development"
 license = "MIT"

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
         box = pkgs.rustPlatform.buildRustPackage {
           pname = "box";
-          version = "0.2.0";
+          version = "0.2.1";
 
           src = ./.;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ use std::path::{Path, PathBuf};
 #[command(
     name = "box",
     about = "Sandboxed git workspaces for development",
-    after_help = "Examples:\n  box                                         # interactive session manager\n  box new my-feature --repo app-a              # create a new session\n  box new my-feature --repo app-a --repo app-b # select specific repos\n  box new my-feature --preset work             # create session from preset\n  box new my-feature --repo app --strategy worktree # use git worktree\n  box new my-feature --repo app --no-fetch     # skip git fetch (faster, uses local refs)\n  box edit my-feature                          # add/remove repos in a session (TUI)\n  box edit my-feature --add app-c --remove app-a # non-interactive edit\n  box list                                     # list all sessions\n  box remove                                   # interactive session removal\n  box remove my-feature                        # remove a session by name\n  box remove --all                             # remove every session\n  box switch my-feature                        # switch to a session\n  box rebase main                              # fetch origin and rebase HEAD onto main\n  box repo add .                               # register current dir as a repo\n  box repo list                                # list registered repos\n  box repo remove my-app                       # unregister a repo\n  box preset add work --repo app-a --repo app-b # define a preset\n  box preset edit work                          # edit repos in a preset\n  box preset list                               # list presets\n  box preset remove work                        # remove a preset\n  box upgrade                                  # self-update"
+    after_help = "Examples:\n  box                                         # interactive session manager\n  box new my-feature --repo app-a              # create a new session\n  box new my-feature --repo app-a --repo app-b # select specific repos\n  box new my-feature --preset work             # create session from preset\n  box new my-feature --repo app --strategy worktree # use git worktree\n  box new my-feature --repo app --no-fetch     # skip git fetch (faster, uses local refs)\n  box edit my-feature                          # add/remove repos in a session (TUI)\n  box edit my-feature --add app-c --remove app-a # non-interactive edit\n  box list                                     # list all sessions\n  box remove                                   # interactive session removal\n  box remove my-feature                        # remove a session by name\n  box remove --all                             # remove every session\n  box switch my-feature                        # switch to a session\n  box rebase main                              # fetch origin and rebase HEAD onto main\n  box repo add git@github.com:user/app.git     # register a repo from a remote URL\n  box repo add .                               # register current dir as a repo\n  box repo list                                # list registered repos\n  box repo remove my-app                       # unregister a repo\n  box preset add work --repo app-a --repo app-b # define a preset\n  box preset edit work                          # edit repos in a preset\n  box preset list                               # list presets\n  box preset remove work                        # remove a preset\n  box upgrade                                  # self-update"
 )]
 struct Cli {
     /// Show detailed output
@@ -77,8 +77,9 @@ enum Commands {
 enum RepoAction {
     /// Register a git repo
     Add {
-        /// Path to the repo (defaults to current directory)
-        path: Option<String>,
+        /// Git remote URL (e.g. git@github.com:user/app.git) or local path
+        /// to a repo (defaults to current directory)
+        src: Option<String>,
     },
     /// Unregister a repo by name
     #[command(alias = "rm")]
@@ -203,7 +204,7 @@ fn main() {
         Some(Commands::Switch { name }) => cmd_cd(&name),
         Some(Commands::Rebase { branch }) => cmd_rebase(&branch, verbose),
         Some(Commands::Repo { action }) => match action {
-            RepoAction::Add { path } => cmd_repo_add(path),
+            RepoAction::Add { src } => cmd_repo_add(src),
             RepoAction::Remove { name } => cmd_repo_remove(&name),
             RepoAction::List => cmd_repo_list(),
         },
@@ -474,7 +475,7 @@ fn cmd_create(
     };
 
     if selected_repos.is_empty() {
-        bail!("No repos registered. Run `box repo add <path>` first.");
+        bail!("No repos registered. Run `box repo add <url>` first.");
     }
 
     let repo_names_list: Vec<String> = selected_repos.iter().map(|r| r.name.clone()).collect();
@@ -786,9 +787,9 @@ fn cmd_rebase(branch: &str, verbose: bool) -> Result<i32> {
     Ok(if status.success() { 0 } else { 1 })
 }
 
-fn cmd_repo_add(path: Option<String>) -> Result<i32> {
-    let path = path.unwrap_or_else(|| ".".to_string());
-    repo::add(&path)?;
+fn cmd_repo_add(src: Option<String>) -> Result<i32> {
+    let src = src.unwrap_or_else(|| ".".to_string());
+    repo::add(&src)?;
     Ok(0)
 }
 
@@ -1401,9 +1402,9 @@ mod tests {
         let cli = parse(&["repo", "add"]);
         match cli.command {
             Some(Commands::Repo {
-                action: RepoAction::Add { path },
+                action: RepoAction::Add { src },
             }) => {
-                assert!(path.is_none());
+                assert!(src.is_none());
             }
             other => panic!("expected Repo Add, got {:?}", other),
         }
@@ -1414,9 +1415,22 @@ mod tests {
         let cli = parse(&["repo", "add", "/tmp/my-repo"]);
         match cli.command {
             Some(Commands::Repo {
-                action: RepoAction::Add { path },
+                action: RepoAction::Add { src },
             }) => {
-                assert_eq!(path.as_deref(), Some("/tmp/my-repo"));
+                assert_eq!(src.as_deref(), Some("/tmp/my-repo"));
+            }
+            other => panic!("expected Repo Add, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_repo_add_with_url() {
+        let cli = parse(&["repo", "add", "git@github.com:user/app.git"]);
+        match cli.command {
+            Some(Commands::Repo {
+                action: RepoAction::Add { src },
+            }) => {
+                assert_eq!(src.as_deref(), Some("git@github.com:user/app.git"));
             }
             other => panic!("expected Repo Add, got {:?}", other),
         }

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -144,19 +144,32 @@ fn mark_migrations_current(bare_dir: &Path) {
     let _ = fs::write(bare_dir.join(MIGRATIONS_SENTINEL), MIGRATIONS_VERSION);
 }
 
-pub fn add(path: &str) -> Result<()> {
-    let canonical =
-        fs::canonicalize(path).map_err(|_| anyhow::anyhow!("Path '{}' does not exist.", path))?;
-    let canonical_str = canonical.to_string_lossy().to_string();
+/// Register a repo from either a git remote URL (e.g.
+/// `git@github.com:user/app.git` or `https://github.com/user/app`) or a local
+/// filesystem path to a git repository.
+pub fn add(src: &str) -> Result<()> {
+    // `clone_src` is what we hand to `git clone --bare`; `repoint` carries the
+    // local source path when we still need to rewrite origin afterwards.
+    let (name, clone_src, repoint): (String, String, Option<String>) = if is_remote_url(src) {
+        let name = repo_name_from_url(src)
+            .ok_or_else(|| anyhow::anyhow!("Cannot derive repo name from URL '{}'.", src))?;
+        (name, src.to_string(), None)
+    } else {
+        let canonical =
+            fs::canonicalize(src).map_err(|_| anyhow::anyhow!("Path '{}' does not exist.", src))?;
+        let canonical_str = canonical.to_string_lossy().to_string();
 
-    if !crate::git::is_repo(&canonical) {
-        bail!("'{}' is not a git repository.", canonical_str);
-    }
+        if !crate::git::is_repo(&canonical) {
+            bail!("'{}' is not a git repository.", canonical_str);
+        }
 
-    let name = canonical
-        .file_name()
-        .map(|n| n.to_string_lossy().to_string())
-        .ok_or_else(|| anyhow::anyhow!("Cannot derive repo name from path."))?;
+        let name = canonical
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .ok_or_else(|| anyhow::anyhow!("Cannot derive repo name from path."))?;
+
+        (name, canonical_str.clone(), Some(canonical_str))
+    };
 
     let existing = list()?;
     for entry in &existing {
@@ -173,7 +186,7 @@ pub fn add(path: &str) -> Result<()> {
 
     eprintln!("\x1b[2mbare-cloning {}…\x1b[0m", name);
     let status = Command::new("git")
-        .args(["clone", "--bare", &canonical_str, &dest_str])
+        .args(["clone", "--bare", &clone_src, &dest_str])
         .status()?;
     if !status.success() {
         bail!("git clone --bare failed for '{}'.", name);
@@ -184,8 +197,12 @@ pub fn add(path: &str) -> Result<()> {
     // directly onto the bare repo's local refs.
     configure_fetch_refspec(&dest_str)?;
 
-    // Repoint origin to the actual remote URL (not the local path)
-    repoint_origin(&canonical_str, &dest_str);
+    // For a local-path source, origin points at the local path; repoint it to
+    // the source repo's actual remote URL. A remote-URL source already has the
+    // correct origin, so there is nothing to repoint.
+    if let Some(source) = repoint {
+        repoint_origin(&source, &dest_str);
+    }
 
     // Newly-created bare: refspec + push.autoSetupRemote were just set, and
     // there are no box/* branches yet. Mark migrations current so the next
@@ -194,6 +211,38 @@ pub fn add(path: &str) -> Result<()> {
 
     eprintln!("Registered repo '\x1b[1m{}\x1b[0m' (bare clone)", name);
     Ok(())
+}
+
+/// Heuristically decide whether `src` is a git remote URL rather than a local
+/// filesystem path. Recognizes scheme URLs (`https://`, `ssh://`, `git://`,
+/// `file://`, …) and scp-like syntax (`user@host:path`, `host:path`).
+fn is_remote_url(src: &str) -> bool {
+    if src.contains("://") {
+        return true;
+    }
+    // Explicit local-path markers can't be scp-like remotes.
+    if src.starts_with('.') || src.starts_with('/') || src.starts_with('~') {
+        return false;
+    }
+    // scp-like syntax has a colon before the path, with no slash in the host
+    // part (e.g. `git@github.com:user/repo.git`).
+    match src.split_once(':') {
+        Some((host, _)) => !host.is_empty() && !host.contains('/'),
+        None => false,
+    }
+}
+
+/// Derive a repo name from a git remote URL by taking the last path segment
+/// and stripping a trailing `.git`. e.g. `git@github.com:user/app.git` => `app`.
+fn repo_name_from_url(url: &str) -> Option<String> {
+    let trimmed = url.trim_end_matches('/');
+    let last = trimmed.rsplit(['/', ':']).next()?;
+    let name = last.strip_suffix(".git").unwrap_or(last);
+    if name.is_empty() {
+        None
+    } else {
+        Some(name.to_string())
+    }
 }
 
 /// Check and fix fetch refspec and `push.autoSetupRemote` on an existing bare
@@ -458,6 +507,47 @@ mod tests {
             .unwrap();
         assert!(status.success(), "git commit failed");
         dir
+    }
+
+    #[test]
+    fn test_is_remote_url() {
+        assert!(is_remote_url("git@github.com:user/app.git"));
+        assert!(is_remote_url("https://github.com/user/app.git"));
+        assert!(is_remote_url("https://github.com/user/app"));
+        assert!(is_remote_url("ssh://git@github.com/user/app.git"));
+        assert!(is_remote_url("git://github.com/user/app.git"));
+        assert!(is_remote_url("github.com:user/app.git"));
+
+        assert!(!is_remote_url("."));
+        assert!(!is_remote_url("./repo"));
+        assert!(!is_remote_url("/abs/path/repo"));
+        assert!(!is_remote_url("~/repo"));
+        assert!(!is_remote_url("relative/path"));
+        assert!(!is_remote_url("repo"));
+    }
+
+    #[test]
+    fn test_repo_name_from_url() {
+        assert_eq!(
+            repo_name_from_url("git@github.com:user/app.git").as_deref(),
+            Some("app")
+        );
+        assert_eq!(
+            repo_name_from_url("https://github.com/user/app.git").as_deref(),
+            Some("app")
+        );
+        assert_eq!(
+            repo_name_from_url("https://github.com/user/app").as_deref(),
+            Some("app")
+        );
+        assert_eq!(
+            repo_name_from_url("https://github.com/user/app/").as_deref(),
+            Some("app")
+        );
+        assert_eq!(
+            repo_name_from_url("ssh://git@host:22/user/app.git").as_deref(),
+            Some("app")
+        );
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -192,7 +192,7 @@ fn clear_viewport(
 pub fn create_session() -> Result<TuiAction> {
     let all_repos = repo::list()?;
     if all_repos.is_empty() {
-        anyhow::bail!("No repos registered. Run `box repo add <path>` first.");
+        anyhow::bail!("No repos registered. Run `box repo add <url>` first.");
     }
 
     let mut presets = preset::list()?;
@@ -521,7 +521,7 @@ fn select_repos(
     initial_selected: Vec<bool>,
 ) -> Result<TuiAction> {
     if all_repos.is_empty() {
-        anyhow::bail!("No repos registered. Run `box repo add <path>` first.");
+        anyhow::bail!("No repos registered. Run `box repo add <url>` first.");
     }
 
     let repo_count = all_repos.len();


### PR DESCRIPTION
## Summary
- `box repo add <src>` now accepts a **git remote URL** (e.g. `git@github.com:user/app.git`, `https://github.com/user/app`, `ssh://…`) in addition to the existing local-path behavior.
- Remote URLs are bare-cloned directly from the URL; the repo name is derived from the last URL segment (with `.git` stripped) and origin is already correct, so the local-path origin-repoint step is skipped.
- Local paths (including the default `.`) keep working exactly as before.

## Code Review
Reviewed the full diff collaboratively via `hew`. No changes requested (empty action log).

Findings surfaced and intentionally left:
- **Low** — `add()` doesn't call `validate_name()` on the derived name. A crafted URL ending in `..` yields a benign `...git` dir (no traversal). Pre-existing gap in the local-path branch too, not a regression.
- **Low/by-design** — scp-like detection (`host:path`) can misclassify a relative local path containing a colon before any slash (e.g. `my:repo`) as a remote. This matches git's own scp-URL ambiguity.

### Review Checklist
- [x] Formatter — passed (`cargo fmt`)
- [x] Linter / static checks — passed (`cargo clippy --all-targets`, no warnings)
- [x] Tests — passed (134 passed, incl. new `test_is_remote_url`, `test_repo_name_from_url`, `test_repo_add_with_url`)
- [x] Full diff reviewed against: correctness, error handling, performance, security, conventions, tests, dead code

### Notes for Reviewer
The two Low-priority items above are pre-existing/by-design and left for a future change if desired.

## Test plan
- `cargo test` — all unit tests pass.
- Manual: `box repo add git@github.com:user/app.git` registers a bare clone with correct origin; `box repo add .` still registers the current directory.