### PR TITLE
Redesign CLI as explicit noun-verb groups (v0.3.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "box-cli"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "box-cli"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 description = "Sandboxed git workspaces for development"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A CLI tool that manages sandboxed git workspaces. Multi-repo support included.
 
 Box creates and manages named workspaces using `git worktree` (default) or `git clone --local`.
 
-- Register repos with `box repo add` (bare-cloned to `~/.box/repos/`), then create sessions — each session sets up repos in `~/.box/workspaces/<session>/`
+- Register sources with `box source add` (bare-cloned to `~/.box/repos/`), then create workspaces — each workspace sets up repos in `~/.box/workspaces/<name>/`
 - Multiple repos can be grouped into a single session, or saved as a named **preset** for reuse
 - Worktree mode is lightweight and fast; clone mode gives full `.git` isolation
 
@@ -62,115 +62,126 @@ Pre-built binaries are available on the [GitHub Releases](https://github.com/yus
 ## Quick Start
 
 ```bash
-# 1. Register a repo
-box repo add ~/projects/my-app
+# 1. Register a source
+box source add ~/projects/my-app
 
-# 2. Create a session via TUI
+# 2. Create a workspace via TUI
 box
 
 # 3. Or create via CLI
-box new my-feature --repo my-app
+box workspace add my-feature --repo my-app
 
 # 4. Switch into the workspace later
-box switch my-feature
+box workspace switch my-feature
 
 # 5. Clean up
-box remove my-feature
+box workspace remove my-feature
 ```
 
 ## Usage
 
+Box has a three-tier model: a **source** is a registered upstream git repo, a
+**workspace** is a named sandbox built from one or more sources, and a **repo**
+is a source checked out inside a workspace (or listed in a preset). Every
+command targets an explicit object — there is no implicit current-directory
+resolution.
+
 ```bash
-box                                        Interactive TUI (create new sessions)
-box new <name> --repo <r> [options]        Create a new session
-box edit <name> [--add <r>] [--remove <r>] Add/remove repos in a session
-box list [options]                         List sessions (alias: ls)
-box remove [<name>] [--all]                Remove a session (alias: rm)
-box switch <name>                          Switch into the session workspace (aliases: cd, sw)
-box rebase <branch>                        Fetch origin and rebase HEAD onto <branch>
-box repo add [path]                        Register a git repo (bare clone)
-box repo remove <name>                     Unregister a repo (alias: rm)
-box repo list                              List registered repos (alias: ls)
-box preset add <name> --repo <r>...        Create or update a preset
-box preset edit <name>                     Edit repos in a preset (TUI)
-box preset remove <name>                   Remove a preset (alias: rm)
-box preset list                            List presets (alias: ls)
-box config zsh|bash                        Output shell configuration
-box upgrade                                Upgrade to latest version
+box                                         Interactive TUI (create a workspace)
+box workspace add <name> --repo <r> [opts]  Create a workspace (alias: ws)
+box workspace list [-q]                     List workspaces (alias: ls)
+box workspace remove [<name>] [--all]       Remove a workspace (alias: rm)
+box workspace switch <name>                 Switch into a workspace (alias: sw)
+box repo add <r>... --workspace|--preset <name>     Add repo(s) to a workspace/preset
+box repo remove <r>... --workspace|--preset <name>  Remove repo(s) (alias: rm)
+box repo list --workspace|--preset <name>           List repos (alias: ls)
+box source add <url|path>                   Register a source (bare clone; `.` = cwd)
+box source remove <name>                    Unregister a source (alias: rm)
+box source list                             List registered sources (alias: ls)
+box preset add <name> --repo <r>...         Create or update a preset
+box preset remove <name>                    Remove a preset (alias: rm)
+box preset list                             List presets (alias: ls)
+box rebase <branch> --workspace <name> --repo <r>   Fetch origin and rebase a repo
+box config zsh|bash                         Output shell configuration
+box upgrade                                 Upgrade to latest version
 ```
+
+Subcommand aliases: `workspace`=`ws`, and within each group `list`=`ls`,
+`remove`=`rm`, `switch`=`sw`.
 
 `-v`/`--verbose` is a global flag (also via `BOX_VERBOSE=1`) that turns on detailed output.
 
-### Create a session
+### Create a workspace
 
 ```bash
 # Default (worktree strategy)
-box new my-feature --repo my-app
+box workspace add my-feature --repo my-app
 
 # Use clone strategy for full isolation
-box new my-feature --repo my-app --strategy clone
+box workspace add my-feature --repo my-app --strategy clone
 
 # Multiple repos
-box new my-feature --repo frontend --repo backend
+box workspace add my-feature --repo frontend --repo backend
 
 # From a preset
-box new my-feature --preset work
+box workspace add my-feature --preset work
 ```
 
-`--repo` (repeatable) or `--preset` is required. To create sessions interactively, run `box` with no arguments.
+`--repo` (repeatable) or `--preset` is required. To create workspaces interactively, run `box` with no arguments.
 
-### Edit session repos
+### Add / remove repos in a workspace
 
 ```bash
-box edit my-feature                                # TUI: toggle repos
-box edit my-feature --add app-c                    # non-interactive add
-box edit my-feature --add app-c --remove app-a     # add and remove
+box repo add app-c --workspace my-feature            # add one repo
+box repo add app-c app-d --workspace my-feature      # add several
+box repo remove app-a --workspace my-feature         # remove a repo
+box repo list --workspace my-feature                 # list repos in the workspace
 ```
 
-`--add` and `--remove` may be repeated. When either is set, the TUI is skipped.
+The same `box repo` group manages preset membership — swap `--workspace <name>`
+for `--preset <name>`. Exactly one of `--workspace` / `--preset` is required.
 
-### List and manage sessions
+### List and manage workspaces
 
 ```bash
-box list                        # List all sessions
-box ls                          # Alias
-box list -q                     # Names only (for scripting)
-box list -p                     # Only sessions for the current project
-box remove my-feature           # Remove a session by name
-box remove                      # Interactive selector (multi-select)
-box remove --all                # Remove every session
+box workspace list              # List all workspaces
+box workspace ls                # Alias
+box workspace list -q           # Names only (for scripting)
+box workspace remove my-feature # Remove a workspace by name
+box workspace remove            # Interactive selector (multi-select)
+box workspace remove --all      # Remove every workspace
 ```
 
 ### Switch into a workspace
 
 ```bash
-box switch my-feature           # Switch into the session workspace
-box cd my-feature               # Alias
-box sw my-feature               # Alias
+box workspace switch my-feature # Switch into the workspace
+box workspace sw my-feature     # Alias
+box ws sw my-feature            # `ws` is an alias of `workspace`
 ```
 
-With shell integration enabled (`eval "$(box config zsh)"`), `box switch` changes your working directory. If you set `BOX_POST_SWITCH_HOOK`, it also runs that hook with the session name (see [Shell Integration](#shell-integration)). Without shell integration, the workspace path is printed to stdout.
+With shell integration enabled (`eval "$(box config zsh)"`), `box workspace switch` changes your working directory. If you set `BOX_POST_SWITCH_HOOK`, it also runs that hook with the workspace name (see [Shell Integration](#shell-integration)). Without shell integration, the workspace path is printed to stdout.
 
-### Rebase the current branch
+### Rebase a workspace repo
 
 ```bash
-box rebase main                 # fetch origin in the bare repo, then rebase HEAD onto main
+box rebase main --workspace my-feature --repo my-app   # fetch origin, then rebase onto main
 ```
 
-`box rebase` runs from inside any session worktree. It fetches the bare repo behind the worktree (handling sibling-worktree branches safely) and then runs `git rebase <branch>` in the current worktree.
+`box rebase` targets an explicit workspace repo. It fetches the bare repo behind the worktree (handling sibling-worktree branches safely) and then runs `git rebase <branch>` in that repo's worktree.
 
 ## Multi-repo Workspaces
 
-Register repos (bare-cloned to `~/.box/repos/`), then reference them by name when creating sessions:
+Register sources (bare-cloned to `~/.box/repos/`), then reference them by name when creating workspaces:
 
 ```bash
-box repo add ~/projects/frontend
-box repo add ~/projects/backend
+box source add ~/projects/frontend
+box source add ~/projects/backend
 
-box new my-feature --repo frontend --repo backend
+box workspace add my-feature --repo frontend --repo backend
 ```
 
-Repos are always fetched before session creation. Each repo is set up in `~/.box/workspaces/<session>/<repo>/`. For single-repo sessions, the workspace path resolves directly to the repo subdirectory.
+Repos are always fetched before workspace creation. Each repo is set up in `~/.box/workspaces/<workspace>/<repo>/`. For single-repo workspaces, the workspace path resolves directly to the repo subdirectory.
 
 ### Presets
 
@@ -179,45 +190,48 @@ A preset is a named list of repos you create sessions from regularly:
 ```bash
 box preset add work --repo frontend --repo backend   # define
 box preset add work                                  # interactive selector
-box preset edit work                                 # update repos (TUI)
+box repo add api --preset work                       # add a repo to the preset
+box repo remove backend --preset work                # remove a repo from the preset
+box repo list --preset work                          # list the preset's repos
 box preset list                                      # list presets
 box preset remove work                               # delete
 
-box new my-feature --preset work                     # use it
+box workspace add my-feature --preset work           # use it
 ```
 
 ## Options
 
-### `box new`
+### `box workspace add`
 
 | Option | Description |
 |--------|-------------|
-| `<name>` | Session name (required) |
+| `<name>` | Workspace name (required) |
 | `--repo <name>` | Repos to include (repeatable; mutually exclusive with `--preset`) |
 | `--preset <name>` | Use a preset (mutually exclusive with `--repo`) |
 | `--strategy <strategy>` | `worktree` (default) or `clone` |
 
-### `box edit`
+### `box repo add` / `box repo remove` / `box repo list`
 
 | Option | Description |
 |--------|-------------|
-| `<name>` | Session name (required) |
-| `--add <repo>` | Add a repo (repeatable; skips the TUI when set) |
-| `--remove <repo>` | Remove a repo (repeatable; skips the TUI when set) |
+| `<repo>...` | Repo name(s) (required for add/remove) |
+| `--workspace <name>` | Target workspace (mutually exclusive with `--preset`) |
+| `--preset <name>` | Target preset (mutually exclusive with `--workspace`) |
 
-### `box list`
+Exactly one of `--workspace` / `--preset` must be given.
 
-| Option | Description |
-|--------|-------------|
-| `--project`, `-p` | Show only sessions for the current project directory |
-| `--quiet`, `-q` | Only print session names |
-
-### `box remove`
+### `box workspace list`
 
 | Option | Description |
 |--------|-------------|
-| `<name>` | Session name (omit to open interactive selector) |
-| `--all`, `-a` | Remove every session (conflicts with `<name>`) |
+| `--quiet`, `-q` | Only print workspace names |
+
+### `box workspace remove`
+
+| Option | Description |
+|--------|-------------|
+| `<name>` | Workspace name (omit to open interactive selector) |
+| `--all`, `-a` | Remove every workspace (conflicts with `<name>`) |
 
 ## Environment Variables
 
@@ -226,7 +240,7 @@ box new my-feature --preset work                     # use it
 | `BOX_STRATEGY` | Default workspace strategy (`worktree` or `clone`). Overridden by `--strategy` |
 | `BOX_VERBOSE` | When set, equivalent to `--verbose` |
 | `BOX_ROOT` | Override the box data directory (default `~/.box`). Read by the shell completions |
-| `BOX_POST_SWITCH_HOOK` | Shell snippet run after `box switch` / `box new`. The session name is available as `$BOX_SESSION_NAME`. See [Shell Integration](#shell-integration) |
+| `BOX_POST_SWITCH_HOOK` | Shell snippet run after `box workspace switch` / `box workspace add`. The workspace name is available as `$BOX_SESSION_NAME`. See [Shell Integration](#shell-integration) |
 
 ## Shell Integration
 
@@ -240,13 +254,13 @@ eval "$(box config bash)"
 
 This provides:
 
-- Tab completion for sessions, repos, and presets
-- A `box` shell function so `box switch` / `box new` change your working directory
-- A `BOX_POST_SWITCH_HOOK` that runs after switching into or creating a session, with the session name in `$BOX_SESSION_NAME`
+- Tab completion for workspaces, sources, and presets
+- A `box` shell function so `box workspace switch` / `box workspace add` change your working directory
+- A `BOX_POST_SWITCH_HOOK` that runs after switching into or creating a workspace, with the workspace name in `$BOX_SESSION_NAME`
 
 ### Post-switch hook
 
-Set `BOX_POST_SWITCH_HOOK` to any shell snippet you want to run when a session is entered (fires on both `box new` and `box switch`). Common choices:
+Set `BOX_POST_SWITCH_HOOK` to any shell snippet you want to run when a workspace is entered (fires on both `box workspace add` and `box workspace switch`). Common choices:
 
 ```bash
 # tmux — rename the current window
@@ -271,17 +285,17 @@ Box supports two workspace strategies:
 ### Worktree (default)
 
 ```
-~/.box/repos/             box new my-feature        ~/.box/workspaces/my-feature/
+~/.box/repos/         box workspace add my-feature  ~/.box/workspaces/my-feature/
   frontend.git   ──── git worktree add ─────>      frontend/
   backend.git                                      backend/
 ```
 
-`git worktree` creates a lightweight working tree linked to the bare repo. It shares the object store, so creation is instant and uses minimal disk space. Each worktree gets its own `box/<session>` branch, and `box remove` cleans up the worktree properly.
+`git worktree` creates a lightweight working tree linked to the bare repo. It shares the object store, so creation is instant and uses minimal disk space. Each worktree gets its own `box/<name>` branch, and `box workspace remove` cleans up the worktree properly.
 
 ### Clone
 
 ```
-~/.box/repos/             box new my-feature        ~/.box/workspaces/my-feature/
+~/.box/repos/         box workspace add my-feature  ~/.box/workspaces/my-feature/
   frontend.git   ──── git clone --local ────>      frontend/
   backend.git                                      backend/
 ```
@@ -304,7 +318,7 @@ Box supports two workspace strategies:
 | Session metadata | `~/.box/sessions/<session>/` |
 | Presets | `~/.box/presets/<name>` |
 | Default strategy | `git worktree` (override with `--strategy clone`) |
-| Cleanup | `box remove` deletes workspace and session data |
+| Cleanup | `box workspace remove` deletes workspace and session data |
 
 ## License
 

--- a/src/completions/box.bash
+++ b/src/completions/box.bash
@@ -1,111 +1,118 @@
+__box_sessions_list() {
+    local __box_root="${BOX_ROOT:-$HOME/.box}"
+    local out=""
+    if [[ -d "$__box_root/sessions" ]]; then
+        for sess in "$__box_root/sessions"/*/; do
+            ([[ -f "$sess/project_dir" ]] || [[ -f "$sess/repos" ]]) && out+=" $(basename "$sess")"
+        done
+    fi
+    echo "$out"
+}
+
+__box_repos_list() {
+    local __box_root="${BOX_ROOT:-$HOME/.box}"
+    local out=""
+    if [[ -d "$__box_root/repos" ]]; then
+        for bare in "$__box_root/repos"/*.git; do
+            [[ -d "$bare" ]] || continue
+            out+=" $(basename "$bare" .git)"
+        done
+    fi
+    echo "$out"
+}
+
+__box_presets_list() {
+    local __box_root="${BOX_ROOT:-$HOME/.box}"
+    local out=""
+    if [[ -d "$__box_root/presets" ]]; then
+        for f in "$__box_root/presets"/*; do
+            [[ -f "$f" ]] || continue
+            out+=" $(basename "$f")"
+        done
+    fi
+    echo "$out"
+}
+
 _box() {
     local cur prev words cword
     _init_completion || return
 
-    local subcommands="new edit remove rm list switch sw cd rebase repo preset upgrade config"
-    local session_cmds="edit remove rm switch sw cd"
-    local __box_root="${BOX_ROOT:-$HOME/.box}"
+    local subcommands="workspace ws repo source preset rebase upgrade config"
 
     if [[ $cword -eq 1 ]]; then
         COMPREPLY=($(compgen -W "$subcommands" -- "$cur"))
         return
     fi
 
-    local subcmd="${words[1]}"
-    [[ -z "$subcmd" ]] && return
+    local sub="${words[1]}"
+    [[ -z "$sub" ]] && return
 
-    case "$subcmd" in
-        new)
-            case "$cur" in
-                -*)
-                    COMPREPLY=($(compgen -W "--repo --preset --strategy --no-fetch --verbose -v" -- "$cur"))
-                    ;;
-            esac
-            if [[ "$prev" == "--strategy" ]]; then
-                COMPREPLY=($(compgen -W "clone worktree" -- "$cur"))
-            fi
-            ;;
-        list|ls)
-            case "$cur" in
-                -*)
-                    COMPREPLY=($(compgen -W "--project -p --quiet -q" -- "$cur"))
-                    ;;
-            esac
-            ;;
-        edit)
-            if [[ "$prev" == "--add" || "$prev" == "--remove" ]]; then
-                local repos=""
-                if [[ -d "$__box_root/repos" ]]; then
-                    for bare in "$__box_root/repos"/*.git; do
-                        [[ -d "$bare" ]] || continue
-                        local name=$(basename "$bare" .git)
-                        [[ -n "$name" ]] && repos+=" $name"
-                    done
-                fi
-                COMPREPLY=($(compgen -W "$repos" -- "$cur"))
+    case "$sub" in
+        workspace|ws)
+            if [[ $cword -eq 2 ]]; then
+                COMPREPLY=($(compgen -W "add list ls remove rm switch sw" -- "$cur"))
                 return
             fi
-            case "$cur" in
-                -*)
-                    COMPREPLY=($(compgen -W "--add --remove --verbose -v" -- "$cur"))
+            case "${words[2]}" in
+                add)
+                    case "$prev" in
+                        --strategy)
+                            COMPREPLY=($(compgen -W "clone worktree" -- "$cur")); return ;;
+                        --repo)
+                            COMPREPLY=($(compgen -W "$(__box_repos_list)" -- "$cur")); return ;;
+                        --preset)
+                            COMPREPLY=($(compgen -W "$(__box_presets_list)" -- "$cur")); return ;;
+                    esac
+                    [[ "$cur" == -* ]] && COMPREPLY=($(compgen -W "--repo --preset --strategy --no-fetch" -- "$cur"))
                     ;;
-                *)
-                    if [[ $cword -eq 2 ]]; then
-                        local sessions=""
-                        if [[ -d "$__box_root/sessions" ]]; then
-                            for sess in "$__box_root/sessions"/*/; do
-                                ([[ -f "$sess/project_dir" ]] || [[ -f "$sess/repos" ]]) && sessions+=" $(basename "$sess")"
-                            done
-                        fi
-                        COMPREPLY=($(compgen -W "$sessions" -- "$cur"))
+                list|ls)
+                    [[ "$cur" == -* ]] && COMPREPLY=($(compgen -W "--quiet -q" -- "$cur"))
+                    ;;
+                remove|rm)
+                    if [[ "$cur" == -* ]]; then
+                        COMPREPLY=($(compgen -W "--all -a" -- "$cur"))
+                    elif [[ $cword -eq 3 ]]; then
+                        COMPREPLY=($(compgen -W "$(__box_sessions_list)" -- "$cur"))
+                    fi
+                    ;;
+                switch|sw)
+                    if [[ $cword -eq 3 ]]; then
+                        COMPREPLY=($(compgen -W "$(__box_sessions_list)" -- "$cur"))
                     fi
                     ;;
             esac
-            ;;
-        remove|rm)
-            case "$cur" in
-                -*)
-                    COMPREPLY=($(compgen -W "--all -a --verbose -v" -- "$cur"))
-                    ;;
-                *)
-                    if [[ $cword -eq 2 ]]; then
-                        local sessions=""
-                        if [[ -d "$__box_root/sessions" ]]; then
-                            for sess in "$__box_root/sessions"/*/; do
-                                ([[ -f "$sess/project_dir" ]] || [[ -f "$sess/repos" ]]) && sessions+=" $(basename "$sess")"
-                            done
-                        fi
-                        COMPREPLY=($(compgen -W "$sessions" -- "$cur"))
-                    fi
-                    ;;
-            esac
-            ;;
-        switch|sw|cd)
-            if [[ $cword -eq 2 ]]; then
-                local sessions=""
-                if [[ -d "$__box_root/sessions" ]]; then
-                    for sess in "$__box_root/sessions"/*/; do
-                        ([[ -f "$sess/project_dir" ]] || [[ -f "$sess/repos" ]]) && sessions+=" $(basename "$sess")"
-                    done
-                fi
-                COMPREPLY=($(compgen -W "$sessions" -- "$cur"))
-            fi
             ;;
         repo)
+            if [[ $cword -eq 2 ]]; then
+                COMPREPLY=($(compgen -W "add remove rm list ls" -- "$cur"))
+                return
+            fi
+            case "$prev" in
+                --workspace)
+                    COMPREPLY=($(compgen -W "$(__box_sessions_list)" -- "$cur")); return ;;
+                --preset)
+                    COMPREPLY=($(compgen -W "$(__box_presets_list)" -- "$cur")); return ;;
+            esac
+            case "${words[2]}" in
+                add|remove|rm)
+                    if [[ "$cur" == -* ]]; then
+                        COMPREPLY=($(compgen -W "--workspace --preset" -- "$cur"))
+                    else
+                        COMPREPLY=($(compgen -W "$(__box_repos_list)" -- "$cur"))
+                    fi
+                    ;;
+                list|ls)
+                    [[ "$cur" == -* ]] && COMPREPLY=($(compgen -W "--workspace --preset" -- "$cur"))
+                    ;;
+            esac
+            ;;
+        source)
             if [[ $cword -eq 2 ]]; then
                 COMPREPLY=($(compgen -W "add remove rm list ls" -- "$cur"))
             elif [[ $cword -eq 3 ]]; then
                 case "${words[2]}" in
                     remove|rm)
-                        local repos=""
-                        if [[ -d "$__box_root/repos" ]]; then
-                            for bare in "$__box_root/repos"/*.git; do
-                                [[ -d "$bare" ]] || continue
-                                local name=$(basename "$bare" .git)
-                                [[ -n "$name" ]] && repos+=" $name"
-                            done
-                        fi
-                        COMPREPLY=($(compgen -W "$repos" -- "$cur"))
+                        COMPREPLY=($(compgen -W "$(__box_repos_list)" -- "$cur"))
                         ;;
                     add)
                         COMPREPLY=($(compgen -d -- "$cur"))
@@ -115,21 +122,29 @@ _box() {
             ;;
         preset)
             if [[ $cword -eq 2 ]]; then
-                COMPREPLY=($(compgen -W "add edit remove rm list ls" -- "$cur"))
-            elif [[ $cword -eq 3 ]]; then
-                case "${words[2]}" in
-                    edit|remove|rm)
-                        local presets=""
-                        if [[ -d "$__box_root/presets" ]]; then
-                            for f in "$__box_root/presets"/*; do
-                                [[ -f "$f" ]] || continue
-                                presets+=" $(basename "$f")"
-                            done
-                        fi
-                        COMPREPLY=($(compgen -W "$presets" -- "$cur"))
-                        ;;
-                esac
+                COMPREPLY=($(compgen -W "add remove rm list ls" -- "$cur"))
+                return
             fi
+            if [[ "$prev" == "--repo" ]]; then
+                COMPREPLY=($(compgen -W "$(__box_repos_list)" -- "$cur")); return
+            fi
+            case "${words[2]}" in
+                remove|rm)
+                    [[ $cword -eq 3 ]] && COMPREPLY=($(compgen -W "$(__box_presets_list)" -- "$cur"))
+                    ;;
+                add)
+                    [[ "$cur" == -* ]] && COMPREPLY=($(compgen -W "--repo" -- "$cur"))
+                    ;;
+            esac
+            ;;
+        rebase)
+            case "$prev" in
+                --workspace)
+                    COMPREPLY=($(compgen -W "$(__box_sessions_list)" -- "$cur")); return ;;
+                --repo)
+                    COMPREPLY=($(compgen -W "$(__box_repos_list)" -- "$cur")); return ;;
+            esac
+            [[ "$cur" == -* ]] && COMPREPLY=($(compgen -W "--workspace --repo" -- "$cur"))
             ;;
         config)
             if [[ $cword -eq 2 ]]; then

--- a/src/completions/box.zsh
+++ b/src/completions/box.zsh
@@ -19,7 +19,7 @@ __box_sessions() {
         done
     fi
     if (( ${#sessions} )); then
-        _describe 'session' sessions
+        _describe 'workspace' sessions
     fi
 }
 
@@ -34,7 +34,7 @@ __box_repos() {
         done
     fi
     if (( ${#repos} )); then
-        _describe 'repo' repos
+        _describe 'source' repos
     fi
 }
 
@@ -64,17 +64,12 @@ _box() {
         subcmd)
             local -a subcmds
             subcmds=(
-                'new:Create a new session'
-                'edit:Edit repos in an existing session'
-                'remove:Remove a session'
-                'rm:Remove a session'
-                'list:List sessions'
-                'switch:Switch to a session'
-                'sw:Switch to a session'
-                'cd:Switch to a session'
-                'rebase:Fetch origin and rebase the current branch'
-                'repo:Manage registered repos'
-                'preset:Manage session presets'
+                'workspace:Manage workspaces (create, list, switch, remove)'
+                'ws:Manage workspaces (alias of workspace)'
+                'repo:Manage repos within a workspace or preset'
+                'source:Manage registered sources (upstream git repos)'
+                'preset:Manage presets'
+                'rebase:Fetch origin and rebase a workspace repo'
                 'upgrade:Self-update to the latest version'
                 'config:Output shell configuration'
             )
@@ -82,51 +77,85 @@ _box() {
             ;;
         args)
             case $words[1] in
-                new)
-                    _arguments \
-                        '*--repo=[Select specific repo]:repo:__box_repos' \
-                        '--preset=[Use a preset]:preset:__box_presets' \
-                        '--strategy=[Workspace strategy]:strategy:(clone worktree)' \
-                        '--no-fetch[Skip git fetch before creating the workspace]' \
-                        '(-v --verbose)'{-v,--verbose}'[Show detailed output]' \
-                        '1:session name:' \
-                        '*:command:'
-                    ;;
-                list|ls)
-                    _arguments \
-                        '--project[Show only sessions for the current project]' \
-                        '-p[Show only sessions for the current project]' \
-                        '--quiet[Only print session names]' \
-                        '-q[Only print session names]'
-                    ;;
-                remove|rm)
-                    _arguments \
-                        '(-v --verbose)'{-v,--verbose}'[Show detailed output]' \
-                        '(-a --all)'{-a,--all}'[Remove every session]' \
-                        '1:session name:__box_sessions'
-                    ;;
-                edit)
-                    _arguments \
-                        '(-v --verbose)'{-v,--verbose}'[Show detailed output]' \
-                        '*--add=[Add a repo to the session]:repo:__box_repos' \
-                        '*--remove=[Remove a repo from the session]:repo:__box_repos' \
-                        '1:session name:__box_sessions'
-                    ;;
-                switch|sw|cd)
+                workspace|ws)
                     if (( CURRENT == 2 )); then
-                        __box_sessions
-                    fi
-                    ;;
-                rebase)
-                    if (( CURRENT == 2 )); then
-                        _message 'branch (e.g. main)'
+                        local -a ws_subcmds
+                        ws_subcmds=(
+                            'add:Create a new workspace'
+                            'list:List workspaces'
+                            'ls:List workspaces'
+                            'remove:Remove a workspace'
+                            'rm:Remove a workspace'
+                            'switch:Switch into a workspace'
+                            'sw:Switch into a workspace'
+                        )
+                        _describe 'workspace subcommand' ws_subcmds
+                    else
+                        case $words[2] in
+                            add)
+                                _arguments \
+                                    '*--repo=[Select specific source]:source:__box_repos' \
+                                    '--preset=[Use a preset]:preset:__box_presets' \
+                                    '--strategy=[Workspace strategy]:strategy:(clone worktree)' \
+                                    '--no-fetch[Skip git fetch before creating the workspace]'
+                                ;;
+                            list|ls)
+                                _arguments \
+                                    '(-q --quiet)'{-q,--quiet}'[Only print workspace names]'
+                                ;;
+                            remove|rm)
+                                if [[ $words[CURRENT] == -* ]]; then
+                                    _arguments '(-a --all)'{-a,--all}'[Remove every workspace]'
+                                elif (( CURRENT == 3 )); then
+                                    __box_sessions
+                                fi
+                                ;;
+                            switch|sw)
+                                if (( CURRENT == 3 )); then
+                                    __box_sessions
+                                fi
+                                ;;
+                        esac
                     fi
                     ;;
                 repo)
                     if (( CURRENT == 2 )); then
                         local -a repo_subcmds
-                        repo_subcmds=('add:Register a git repo' 'remove:Unregister a repo' 'rm:Unregister a repo' 'list:List registered repos' 'ls:List registered repos')
+                        repo_subcmds=(
+                            'add:Add repo(s) to a workspace or preset'
+                            'remove:Remove repo(s) from a workspace or preset'
+                            'rm:Remove repo(s) from a workspace or preset'
+                            'list:List repos in a workspace or preset'
+                            'ls:List repos in a workspace or preset'
+                        )
                         _describe 'repo subcommand' repo_subcmds
+                    else
+                        case $words[2] in
+                            add|remove|rm)
+                                _arguments \
+                                    '--workspace=[Target workspace]:workspace:__box_sessions' \
+                                    '--preset=[Target preset]:preset:__box_presets' \
+                                    '*:source:__box_repos'
+                                ;;
+                            list|ls)
+                                _arguments \
+                                    '--workspace=[Target workspace]:workspace:__box_sessions' \
+                                    '--preset=[Target preset]:preset:__box_presets'
+                                ;;
+                        esac
+                    fi
+                    ;;
+                source)
+                    if (( CURRENT == 2 )); then
+                        local -a source_subcmds
+                        source_subcmds=(
+                            'add:Register a git repo as a source'
+                            'remove:Unregister a source'
+                            'rm:Unregister a source'
+                            'list:List registered sources'
+                            'ls:List registered sources'
+                        )
+                        _describe 'source subcommand' source_subcmds
                     elif (( CURRENT == 3 )); then
                         case $words[2] in
                             remove|rm)
@@ -141,18 +170,30 @@ _box() {
                 preset)
                     if (( CURRENT == 2 )); then
                         local -a preset_subcmds
-                        preset_subcmds=('add:Create or update a preset' 'edit:Edit repos in an existing preset' 'remove:Remove a preset' 'rm:Remove a preset' 'list:List presets' 'ls:List presets')
+                        preset_subcmds=(
+                            'add:Create or update a preset'
+                            'remove:Remove a preset'
+                            'rm:Remove a preset'
+                            'list:List presets'
+                            'ls:List presets'
+                        )
                         _describe 'preset subcommand' preset_subcmds
                     elif (( CURRENT == 3 )); then
                         case $words[2] in
-                            edit|remove|rm)
+                            remove|rm)
                                 __box_presets
                                 ;;
                         esac
                     elif [[ $words[2] == "add" ]]; then
                         _arguments \
-                            '*--repo=[Select specific repo]:repo:__box_repos'
+                            '*--repo=[Select specific source]:source:__box_repos'
                     fi
+                    ;;
+                rebase)
+                    _arguments \
+                        '--workspace=[Workspace name]:workspace:__box_sessions' \
+                        '--repo=[Repo within the workspace]:repo:__box_repos' \
+                        '1:branch (e.g. main):'
                     ;;
                 config)
                     if (( CURRENT == 2 )); then

--- a/src/git.rs
+++ b/src/git.rs
@@ -4,20 +4,6 @@ pub fn is_repo(dir: &Path) -> bool {
     dir.join(".git").exists()
 }
 
-/// Walk up from `dir` to find the nearest ancestor containing `.git`.
-pub fn find_root(dir: &Path) -> Option<&Path> {
-    let mut current = dir;
-    loop {
-        if is_repo(current) {
-            return Some(current);
-        }
-        match current.parent() {
-            Some(parent) => current = parent,
-            None => return None,
-        }
-    }
-}
-
 /// Fetch all refs for a bare repo, capturing output.
 ///
 /// Uses `--prune` so local heads whose upstream counterpart was deleted are
@@ -158,40 +144,6 @@ mod tests {
     #[test]
     fn test_is_repo_nonexistent() {
         assert!(!is_repo(Path::new("/nonexistent/path/12345")));
-    }
-
-    #[test]
-    fn test_find_root_at_root() {
-        let tmp = tempfile::tempdir().unwrap();
-        std::process::Command::new("git")
-            .args(["init", tmp.path().to_str().unwrap()])
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
-            .unwrap();
-        assert_eq!(find_root(tmp.path()), Some(tmp.path()));
-    }
-
-    #[test]
-    fn test_find_root_from_subdirectory() {
-        let tmp = tempfile::tempdir().unwrap();
-        std::process::Command::new("git")
-            .args(["init", tmp.path().to_str().unwrap()])
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
-            .unwrap();
-        let sub = tmp.path().join("a").join("b").join("c");
-        std::fs::create_dir_all(&sub).unwrap();
-        assert_eq!(find_root(&sub), Some(tmp.path()));
-    }
-
-    #[test]
-    fn test_find_root_no_repo() {
-        let tmp = tempfile::tempdir().unwrap();
-        let sub = tmp.path().join("no_repo");
-        std::fs::create_dir_all(&sub).unwrap();
-        assert_eq!(find_root(&sub), None);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,24 @@ use std::path::{Path, PathBuf};
 #[command(
     name = "box",
     about = "Sandboxed git workspaces for development",
-    after_help = "Examples:\n  box                                         # interactive session manager\n  box new my-feature --repo app-a              # create a new session\n  box new my-feature --repo app-a --repo app-b # select specific repos\n  box new my-feature --preset work             # create session from preset\n  box new my-feature --repo app --strategy worktree # use git worktree\n  box new my-feature --repo app --no-fetch     # skip git fetch (faster, uses local refs)\n  box edit my-feature                          # add/remove repos in a session (TUI)\n  box edit my-feature --add app-c --remove app-a # non-interactive edit\n  box list                                     # list all sessions\n  box remove                                   # interactive session removal\n  box remove my-feature                        # remove a session by name\n  box remove --all                             # remove every session\n  box switch my-feature                        # switch to a session\n  box rebase main                              # fetch origin and rebase HEAD onto main\n  box repo add git@github.com:user/app.git     # register a repo from a remote URL\n  box repo add .                               # register current dir as a repo\n  box repo list                                # list registered repos\n  box repo remove my-app                       # unregister a repo\n  box preset add work --repo app-a --repo app-b # define a preset\n  box preset edit work                          # edit repos in a preset\n  box preset list                               # list presets\n  box preset remove work                        # remove a preset\n  box upgrade                                  # self-update"
+    long_about = "box manages sandboxed git workspaces for development.\n\n\
+MENTAL MODEL (three tiers):\n\
+  source     an upstream git repo registered via `box source add`; bare-cloned to ~/.box/repos/.\n\
+  workspace  a named sandbox under ~/.box/workspaces/<name>/ built from one or more sources.\n\
+  repo       a source checked out inside a workspace (also the unit listed in a preset).\n\
+  preset     a named, reusable set of sources used to create workspaces.\n\n\
+TYPICAL FLOW:\n\
+  1. box source add <url|path>                  register a source\n\
+  2. box workspace add <name> --repo <source>   create a workspace (alias: ws)\n\
+  3. box workspace switch <name>                enter it (alias: sw)\n\
+  4. box repo add <source> --workspace <name>   add/remove repos later\n\n\
+CONVENTIONS (important for scripting/agents):\n\
+  - Every command targets an EXPLICIT object. There is no implicit current-directory resolution.\n\
+  - `box repo add|remove|list` requires exactly one of --workspace <name> or --preset <name>.\n\
+  - `box rebase` requires --workspace <name> and --repo <name>.\n\
+  - Subcommand aliases: workspace=ws, and within each group list=ls, remove=rm, switch=sw.\n\
+  - `box` with no arguments launches an interactive TUI to create a workspace.",
+    after_help = "Examples:\n  box                                          # interactive workspace manager\n  box workspace add my-feature --repo app-a    # create a workspace (alias: ws)\n  box workspace add my-feature --preset work   # create from a preset\n  box workspace list                           # list workspaces (alias: ls)\n  box workspace switch my-feature              # switch into a workspace (alias: sw)\n  box workspace remove my-feature              # remove a workspace (alias: rm)\n  box repo add app-c --workspace my-feature    # add a repo to a workspace\n  box repo remove app-a --workspace my-feature # remove a repo from a workspace\n  box repo list --workspace my-feature         # list repos in a workspace\n  box repo add app-c --preset work             # add a repo to a preset\n  box source add git@github.com:user/app.git   # register a source from a URL\n  box source add .                             # register current dir as a source\n  box source list                              # list registered sources\n  box source remove my-app                     # unregister a source\n  box preset add work --repo app-a --repo app-b # define a preset\n  box preset list                              # list presets\n  box rebase main --workspace my-feature --repo app-a # fetch & rebase a repo\n  box upgrade                                  # self-update"
 )]
 struct Cli {
     /// Show detailed output
@@ -33,37 +50,29 @@ struct Cli {
 
 #[derive(Subcommand, Debug)]
 enum Commands {
-    /// Create a new session
-    New(CreateArgs),
-    /// Edit repos in an existing session
-    Edit(EditArgs),
-    /// Remove a session
-    #[command(alias = "rm")]
-    Remove(RemoveArgs),
-    /// List sessions
-    #[command(alias = "ls")]
-    List(ListArgs),
-    /// Switch to a session
-    #[command(alias = "cd", alias = "sw")]
-    Switch {
-        /// Session name
-        name: String,
+    /// Manage workspaces (create, list, switch, remove)
+    #[command(alias = "ws")]
+    Workspace {
+        #[command(subcommand)]
+        action: WorkspaceAction,
     },
-    /// Fetch origin and rebase the current branch onto another branch
-    Rebase {
-        /// Branch to rebase onto (e.g. main)
-        branch: String,
-    },
-    /// Manage registered repos
+    /// Manage repos within a workspace or preset
     Repo {
         #[command(subcommand)]
         action: RepoAction,
     },
-    /// Manage session presets
+    /// Manage registered sources (upstream git repos)
+    Source {
+        #[command(subcommand)]
+        action: SourceAction,
+    },
+    /// Manage presets
     Preset {
         #[command(subcommand)]
         action: PresetAction,
     },
+    /// Fetch origin and rebase a workspace repo onto another branch
+    Rebase(RebaseArgs),
     /// Self-update to the latest version
     Upgrade,
     /// Output shell configuration (e.g. eval "$(box config zsh)")
@@ -74,20 +83,50 @@ enum Commands {
 }
 
 #[derive(Subcommand, Debug)]
-enum RepoAction {
-    /// Register a git repo
-    Add {
-        /// Git remote URL (e.g. git@github.com:user/app.git) or local path
-        /// to a repo (defaults to current directory)
-        src: Option<String>,
-    },
-    /// Unregister a repo by name
+enum WorkspaceAction {
+    /// Create a new workspace
+    Add(CreateArgs),
+    /// List workspaces
+    #[command(alias = "ls")]
+    List(ListArgs),
+    /// Remove a workspace
     #[command(alias = "rm")]
-    Remove {
-        /// Repo name
+    Remove(RemoveArgs),
+    /// Switch into a workspace
+    #[command(alias = "sw")]
+    Switch {
+        /// Workspace name
         name: String,
     },
-    /// List registered repos
+}
+
+#[derive(Subcommand, Debug)]
+enum RepoAction {
+    /// Add repo(s) to a workspace or preset
+    Add(RepoEditArgs),
+    /// Remove repo(s) from a workspace or preset
+    #[command(alias = "rm")]
+    Remove(RepoEditArgs),
+    /// List repos in a workspace or preset
+    #[command(alias = "ls")]
+    List(RepoListArgs),
+}
+
+#[derive(Subcommand, Debug)]
+enum SourceAction {
+    /// Register a git repo as a source
+    Add {
+        /// Git remote URL (e.g. git@github.com:user/app.git) or local path
+        /// to a repo (use `.` for the current directory)
+        src: String,
+    },
+    /// Unregister a source by name
+    #[command(alias = "rm")]
+    Remove {
+        /// Source name
+        name: String,
+    },
+    /// List registered sources
     #[command(alias = "ls")]
     List,
 }
@@ -102,11 +141,6 @@ enum PresetAction {
         #[arg(long)]
         repo: Vec<String>,
     },
-    /// Edit repos in an existing preset
-    Edit {
-        /// Preset name
-        name: String,
-    },
     /// Remove a preset
     #[command(alias = "rm")]
     Remove {
@@ -120,7 +154,7 @@ enum PresetAction {
 
 #[derive(clap::Args, Debug)]
 struct CreateArgs {
-    /// Session name
+    /// Workspace name
     name: String,
 
     /// Select specific repos by name (can be repeated)
@@ -141,37 +175,58 @@ struct CreateArgs {
 }
 
 #[derive(clap::Args, Debug)]
-struct EditArgs {
-    /// Session name
-    name: String,
+struct RepoEditArgs {
+    /// Repo name(s)
+    #[arg(required = true)]
+    repo: Vec<String>,
 
-    /// Add repos to the session (can be repeated). Skips the TUI when set.
-    #[arg(long)]
-    add: Vec<String>,
+    /// Target workspace (mutually exclusive with --preset)
+    #[arg(long, group = "repo_target")]
+    workspace: Option<String>,
 
-    /// Remove repos from the session (can be repeated). Skips the TUI when set.
-    #[arg(long)]
-    remove: Vec<String>,
+    /// Target preset (mutually exclusive with --workspace)
+    #[arg(long, group = "repo_target")]
+    preset: Option<String>,
+}
+
+#[derive(clap::Args, Debug)]
+struct RepoListArgs {
+    /// Target workspace (mutually exclusive with --preset)
+    #[arg(long, group = "repo_target")]
+    workspace: Option<String>,
+
+    /// Target preset (mutually exclusive with --workspace)
+    #[arg(long, group = "repo_target")]
+    preset: Option<String>,
 }
 
 #[derive(clap::Args, Debug)]
 struct RemoveArgs {
-    /// Session name (opens interactive selector if omitted)
+    /// Workspace name (opens interactive selector if omitted)
     name: Option<String>,
 
-    /// Remove every session
+    /// Remove every workspace
     #[arg(long, short = 'a', conflicts_with = "name")]
     all: bool,
 }
 
 #[derive(clap::Args, Debug)]
 struct ListArgs {
-    /// Show only sessions for the current project directory
-    #[arg(long, short)]
-    project: bool,
-    /// Only print session names
+    /// Only print workspace names
     #[arg(long, short)]
     quiet: bool,
+}
+
+#[derive(clap::Args, Debug)]
+struct RebaseArgs {
+    /// Branch to rebase onto (e.g. main)
+    branch: String,
+    /// Workspace name
+    #[arg(long)]
+    workspace: String,
+    /// Repo name within the workspace
+    #[arg(long)]
+    repo: String,
 }
 
 #[derive(Subcommand, Debug)]
@@ -188,32 +243,43 @@ fn main() {
     let verbose = cli.verbose;
 
     let result = match cli.command {
-        Some(Commands::New(args)) => cmd_new(args, verbose),
-        Some(Commands::Edit(args)) => cmd_edit(&args.name, &args.add, &args.remove, verbose),
-        Some(Commands::Remove(args)) => {
-            if args.all {
-                cmd_remove_all(verbose)
-            } else {
-                match &args.name {
-                    Some(name) => cmd_remove(name, verbose),
-                    None => cmd_remove_tui(verbose),
+        Some(Commands::Workspace { action }) => match action {
+            WorkspaceAction::Add(args) => cmd_new(args, verbose),
+            WorkspaceAction::List(args) => cmd_list_sessions(&args),
+            WorkspaceAction::Remove(args) => {
+                if args.all {
+                    cmd_remove_all(verbose)
+                } else {
+                    match &args.name {
+                        Some(name) => cmd_remove(name, verbose),
+                        None => cmd_remove_tui(verbose),
+                    }
                 }
             }
-        }
-        Some(Commands::List(args)) => cmd_list_sessions(&args),
-        Some(Commands::Switch { name }) => cmd_cd(&name),
-        Some(Commands::Rebase { branch }) => cmd_rebase(&branch, verbose),
+            WorkspaceAction::Switch { name } => cmd_cd(&name),
+        },
         Some(Commands::Repo { action }) => match action {
-            RepoAction::Add { src } => cmd_repo_add(src),
-            RepoAction::Remove { name } => cmd_repo_remove(&name),
-            RepoAction::List => cmd_repo_list(),
+            RepoAction::Add(args) => {
+                cmd_repo_modify(&args.repo, args.workspace, args.preset, true, verbose)
+            }
+            RepoAction::Remove(args) => {
+                cmd_repo_modify(&args.repo, args.workspace, args.preset, false, verbose)
+            }
+            RepoAction::List(args) => cmd_repo_list_target(args.workspace, args.preset),
+        },
+        Some(Commands::Source { action }) => match action {
+            SourceAction::Add { src } => cmd_source_add(&src),
+            SourceAction::Remove { name } => cmd_source_remove(&name),
+            SourceAction::List => cmd_source_list(),
         },
         Some(Commands::Preset { action }) => match action {
             PresetAction::Add { name, repo } => cmd_preset_add(&name, &repo),
-            PresetAction::Edit { name } => cmd_preset_edit(&name),
             PresetAction::Remove { name } => cmd_preset_remove(&name),
             PresetAction::List => cmd_preset_list(),
         },
+        Some(Commands::Rebase(args)) => {
+            cmd_rebase(&args.branch, &args.workspace, &args.repo, verbose)
+        }
         Some(Commands::Upgrade) => cmd_upgrade(),
         Some(Commands::Config { shell }) => match shell {
             ConfigShell::Zsh => cmd_config_zsh(),
@@ -298,41 +364,6 @@ pub(crate) fn shorten_project_path(path: &str, home: &str) -> String {
     shortened.join("/")
 }
 
-/// Resolve the current directory to a project_dir suitable for filtering sessions.
-///
-/// 1. If the cwd is inside a workspace (`~/.box/workspaces/<name>/`), look up
-///    that session's project_dir so we can find sibling sessions for the same project.
-/// 2. Otherwise, walk up to the nearest git root and use that.
-fn resolve_project_dir(
-    cwd: &std::path::Path,
-    sessions: &[session::SessionSummary],
-) -> Option<String> {
-    // Check if we're inside a workspace directory
-    if let Ok(root) = config::box_root() {
-        let workspaces = root.join("workspaces");
-        if let Ok(workspaces) = std::fs::canonicalize(&workspaces) {
-            if cwd.starts_with(&workspaces) {
-                // Extract the workspace name (first component after workspaces/)
-                if let Some(ws_name) = cwd.strip_prefix(&workspaces).ok().and_then(|r| {
-                    r.components()
-                        .next()
-                        .map(|c| c.as_os_str().to_string_lossy().to_string())
-                }) {
-                    // Find session with this name to get its project_dir
-                    if let Some(s) = sessions.iter().find(|s| s.name == ws_name) {
-                        if !s.project_dir.is_empty() {
-                            return Some(s.project_dir.clone());
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    // Fall back to git root
-    git::find_root(cwd).map(|r| r.to_string_lossy().to_string())
-}
-
 /// `box` with no args: interactive TUI to create a session.
 fn cmd_default(verbose: bool) -> Result<i32> {
     if std::env::var_os("BOX_SESSION").is_some() {
@@ -354,18 +385,7 @@ fn cmd_create_tui(verbose: bool) -> Result<i32> {
 }
 
 fn cmd_list_sessions(args: &ListArgs) -> Result<i32> {
-    let mut sessions = session::list()?;
-
-    if args.project {
-        let cwd = std::env::current_dir()?;
-        let cwd = std::fs::canonicalize(&cwd).unwrap_or(cwd);
-        let project = resolve_project_dir(&cwd, &sessions);
-        if let Some(project) = project {
-            sessions.retain(|s| s.project_dir == project);
-        } else {
-            sessions.clear();
-        }
-    }
+    let sessions = session::list()?;
 
     if args.quiet {
         for s in &sessions {
@@ -475,7 +495,7 @@ fn cmd_create(
     };
 
     if selected_repos.is_empty() {
-        bail!("No repos registered. Run `box repo add <url>` first.");
+        bail!("No sources registered. Run `box source add <url>` first.");
     }
 
     let repo_names_list: Vec<String> = selected_repos.iter().map(|r| r.name.clone()).collect();
@@ -516,29 +536,98 @@ fn cmd_create(
     Ok(0)
 }
 
-fn cmd_edit(name: &str, add: &[String], remove: &[String], verbose: bool) -> Result<i32> {
-    let name = session::validate_name(name)?;
-    let name = name.as_str();
+/// Target of a `box repo` operation: either a workspace or a preset.
+enum RepoTarget {
+    Workspace(String),
+    Preset(String),
+}
 
-    if !session::session_exists(name)? {
-        bail!("Session '{}' not found.", name);
+/// Resolve the mutually-exclusive --workspace / --preset target, requiring
+/// exactly one to be set. (clap's `repo_target` group already prevents both.)
+fn resolve_repo_target(workspace: Option<String>, preset: Option<String>) -> Result<RepoTarget> {
+    match (workspace, preset) {
+        (Some(w), None) => Ok(RepoTarget::Workspace(w)),
+        (None, Some(p)) => Ok(RepoTarget::Preset(p)),
+        (None, None) => bail!("Specify a target with --workspace <name> or --preset <name>."),
+        (Some(_), Some(_)) => unreachable!("--workspace and --preset are mutually exclusive"),
     }
+}
 
-    let sess = session::load(name)?;
-    let strategy = workspace::Strategy::from_str(&sess.strategy)?;
-    let current_repos = &sess.repos;
+/// Add or remove repos in a workspace or preset (replaces the old `box edit`).
+fn cmd_repo_modify(
+    repos: &[String],
+    workspace: Option<String>,
+    preset: Option<String>,
+    adding: bool,
+    verbose: bool,
+) -> Result<i32> {
+    let (add, remove): (&[String], &[String]) = if adding { (repos, &[]) } else { (&[], repos) };
 
-    if !add.is_empty() || !remove.is_empty() {
-        let new_repos = compute_edit_repos(current_repos, add, remove)?;
-        return apply_edit_diff(name, current_repos, &new_repos, strategy, verbose);
-    }
-
-    match tui::edit_session(current_repos)? {
-        tui::TuiAction::Edit { repos: new_repos } => {
-            apply_edit_diff(name, current_repos, &new_repos, strategy, verbose)
+    match resolve_repo_target(workspace, preset)? {
+        RepoTarget::Workspace(name) => {
+            let name = session::validate_name(&name)?;
+            let name = name.as_str();
+            if !session::session_exists(name)? {
+                bail!("Workspace '{}' not found.", name);
+            }
+            let sess = session::load(name)?;
+            let strategy = workspace::Strategy::from_str(&sess.strategy)?;
+            let new_repos = compute_edit_repos(&sess.repos, add, remove)?;
+            apply_edit_diff(name, &sess.repos, &new_repos, strategy, verbose)
         }
-        _ => Ok(0),
+        RepoTarget::Preset(name) => {
+            let current = preset::load(&name)?;
+            let new_repos = compute_edit_repos(&current, add, remove)?;
+
+            let added: Vec<&str> = new_repos
+                .iter()
+                .filter(|r| !current.contains(r))
+                .map(|r| r.as_str())
+                .collect();
+            let removed: Vec<&str> = current
+                .iter()
+                .filter(|r| !new_repos.contains(r))
+                .map(|r| r.as_str())
+                .collect();
+
+            preset::add(&name, &new_repos)?;
+
+            if !added.is_empty() {
+                eprintln!("\x1b[2madded:\x1b[0m {}", added.join(", "));
+            }
+            if !removed.is_empty() {
+                eprintln!("\x1b[2mremoved:\x1b[0m {}", removed.join(", "));
+            }
+            if added.is_empty() && removed.is_empty() {
+                eprintln!("No changes.");
+            }
+            Ok(0)
+        }
     }
+}
+
+/// List the repos in a workspace or preset.
+fn cmd_repo_list_target(workspace: Option<String>, preset: Option<String>) -> Result<i32> {
+    let repos = match resolve_repo_target(workspace, preset)? {
+        RepoTarget::Workspace(name) => {
+            let name = session::validate_name(&name)?;
+            let name = name.as_str();
+            if !session::session_exists(name)? {
+                bail!("Workspace '{}' not found.", name);
+            }
+            session::load(name)?.repos
+        }
+        RepoTarget::Preset(name) => preset::load(&name)?,
+    };
+
+    if repos.is_empty() {
+        println!("No repos.");
+        return Ok(0);
+    }
+    for r in &repos {
+        println!("{}", r);
+    }
+    Ok(0)
 }
 
 /// Compute the new repo set from --add/--remove flags. Errors when the same
@@ -557,7 +646,7 @@ fn compute_edit_repos(
     for repo_name in add {
         if !all_repos.iter().any(|r| &r.name == repo_name) {
             bail!(
-                "Repo '{}' is not registered. Run `box repo add` first.",
+                "Repo '{}' is not registered. Run `box source add` first.",
                 repo_name
             );
         }
@@ -722,18 +811,25 @@ fn cmd_cd(name: &str) -> Result<i32> {
     Ok(0)
 }
 
-/// Fetch origin in the bare repo backing the current worktree, then rebase
-/// the worktree's current branch onto `branch`.
+/// Fetch origin in the bare repo backing a workspace repo, then rebase that
+/// repo's current branch onto `branch`.
 ///
 /// Box workspaces share a single bare repo across worktrees, and `git fetch`
 /// from a worktree often refuses to update sibling-worktree branches. This
 /// command routes the fetch through `git::fetch_repo`, which knows how to
 /// exclude checked-out branches with negative refspecs.
-fn cmd_rebase(branch: &str, verbose: bool) -> Result<i32> {
-    let cwd = std::env::current_dir()?;
-    let worktree_root = git::find_root(&cwd)
-        .ok_or_else(|| anyhow::anyhow!("Not in a git repository."))?
-        .to_path_buf();
+fn cmd_rebase(branch: &str, workspace: &str, repo: &str, verbose: bool) -> Result<i32> {
+    let workspace = session::validate_name(workspace)?;
+    if !session::session_exists(&workspace)? {
+        bail!("Workspace '{}' not found.", workspace);
+    }
+    let worktree_root = config::box_root()?
+        .join("workspaces")
+        .join(&workspace)
+        .join(repo);
+    if !worktree_root.is_dir() {
+        bail!("Repo '{}' not found in workspace '{}'.", repo, workspace);
+    }
     let worktree_root_str = worktree_root.to_string_lossy().to_string();
 
     let output = std::process::Command::new("git")
@@ -787,21 +883,20 @@ fn cmd_rebase(branch: &str, verbose: bool) -> Result<i32> {
     Ok(if status.success() { 0 } else { 1 })
 }
 
-fn cmd_repo_add(src: Option<String>) -> Result<i32> {
-    let src = src.unwrap_or_else(|| ".".to_string());
-    repo::add(&src)?;
+fn cmd_source_add(src: &str) -> Result<i32> {
+    repo::add(src)?;
     Ok(0)
 }
 
-fn cmd_repo_remove(name: &str) -> Result<i32> {
+fn cmd_source_remove(name: &str) -> Result<i32> {
     repo::remove(name)?;
     Ok(0)
 }
 
-fn cmd_repo_list() -> Result<i32> {
+fn cmd_source_list() -> Result<i32> {
     let repos = repo::list()?;
     if repos.is_empty() {
-        println!("No repos registered.");
+        println!("No sources registered.");
         return Ok(0);
     }
 
@@ -844,19 +939,6 @@ fn cmd_preset_add(name: &str, repos: &[String]) -> Result<i32> {
         }
     } else {
         preset::add(name, repos)?;
-    }
-    Ok(0)
-}
-
-fn cmd_preset_edit(name: &str) -> Result<i32> {
-    let current = preset::load(name)?;
-    match tui::select_preset_repos(&current)? {
-        tui::TuiAction::Edit { repos } => {
-            preset::add(name, &repos)?;
-        }
-        _ => {
-            return Ok(0);
-        }
     }
     Ok(0)
 }
@@ -1029,285 +1111,301 @@ mod tests {
         assert!(cli.command.is_none());
     }
 
-    // -- new subcommand --
+    // -- workspace add subcommand --
 
-    #[test]
-    fn test_new_name_only() {
-        let cli = parse(&["new", "my-session", "--repo", "app"]);
+    fn ws_add(cli: Cli) -> CreateArgs {
         match cli.command {
-            Some(Commands::New(args)) => {
-                assert_eq!(args.name, "my-session");
-                assert_eq!(args.repo, vec!["app"]);
-            }
-            other => panic!("expected New, got {:?}", other),
+            Some(Commands::Workspace {
+                action: WorkspaceAction::Add(args),
+            }) => args,
+            other => panic!("expected Workspace Add, got {:?}", other),
         }
     }
 
     #[test]
-    fn test_new_requires_name() {
-        let result = try_parse(&["new"]);
-        assert!(result.is_err());
+    fn test_workspace_add_name_only() {
+        let args = ws_add(parse(&["workspace", "add", "my-session", "--repo", "app"]));
+        assert_eq!(args.name, "my-session");
+        assert_eq!(args.repo, vec!["app"]);
     }
 
     #[test]
-    fn test_new_name_only_parses() {
+    fn test_workspace_alias_ws() {
+        let args = ws_add(parse(&["ws", "add", "my-session", "--repo", "app"]));
+        assert_eq!(args.name, "my-session");
+    }
+
+    #[test]
+    fn test_workspace_add_requires_name() {
+        assert!(try_parse(&["workspace", "add"]).is_err());
+    }
+
+    #[test]
+    fn test_workspace_add_name_only_parses() {
         // --repo and --preset are both optional at parse time; runtime enforces at least one
-        let cli = parse(&["new", "my-session"]);
+        let args = ws_add(parse(&["workspace", "add", "my-session"]));
+        assert!(args.repo.is_empty());
+        assert!(args.preset.is_none());
+    }
+
+    #[test]
+    fn test_workspace_add_with_preset() {
+        let args = ws_add(parse(&[
+            "workspace",
+            "add",
+            "my-session",
+            "--preset",
+            "work",
+        ]));
+        assert_eq!(args.preset.as_deref(), Some("work"));
+        assert!(args.repo.is_empty());
+    }
+
+    #[test]
+    fn test_workspace_add_preset_and_repo_conflict() {
+        assert!(try_parse(&[
+            "workspace",
+            "add",
+            "my-session",
+            "--preset",
+            "work",
+            "--repo",
+            "app"
+        ])
+        .is_err());
+    }
+
+    #[test]
+    fn test_workspace_add_with_repo_flags() {
+        let args = ws_add(parse(&[
+            "workspace",
+            "add",
+            "my-session",
+            "--repo",
+            "app-a",
+            "--repo",
+            "app-b",
+        ]));
+        assert_eq!(args.repo, vec!["app-a", "app-b"]);
+    }
+
+    #[test]
+    fn test_workspace_add_default_strategy() {
+        let args = ws_add(parse(&["workspace", "add", "my-session", "--repo", "app"]));
+        assert_eq!(args.strategy, "worktree");
+    }
+
+    #[test]
+    fn test_workspace_add_with_strategy_clone() {
+        let args = ws_add(parse(&[
+            "workspace",
+            "add",
+            "my-session",
+            "--repo",
+            "app",
+            "--strategy",
+            "clone",
+        ]));
+        assert_eq!(args.strategy, "clone");
+    }
+
+    #[test]
+    fn test_workspace_add_no_fetch_defaults_false() {
+        let args = ws_add(parse(&["workspace", "add", "my-session", "--repo", "app"]));
+        assert!(!args.no_fetch);
+    }
+
+    #[test]
+    fn test_workspace_add_with_no_fetch_flag() {
+        let args = ws_add(parse(&[
+            "workspace",
+            "add",
+            "my-session",
+            "--repo",
+            "app",
+            "--no-fetch",
+        ]));
+        assert!(args.no_fetch);
+    }
+
+    // -- repo subcommand (workspace/preset repo management) --
+
+    #[test]
+    fn test_repo_add_to_workspace() {
+        let cli = parse(&["repo", "add", "app-c", "--workspace", "my-session"]);
         match cli.command {
-            Some(Commands::New(args)) => {
-                assert!(args.repo.is_empty());
+            Some(Commands::Repo {
+                action: RepoAction::Add(args),
+            }) => {
+                assert_eq!(args.repo, vec!["app-c"]);
+                assert_eq!(args.workspace.as_deref(), Some("my-session"));
                 assert!(args.preset.is_none());
             }
-            other => panic!("expected New, got {:?}", other),
+            other => panic!("expected Repo Add, got {:?}", other),
         }
     }
 
     #[test]
-    fn test_new_with_preset() {
-        let cli = parse(&["new", "my-session", "--preset", "work"]);
+    fn test_repo_add_multiple_to_preset() {
+        let cli = parse(&["repo", "add", "app-c", "app-d", "--preset", "work"]);
         match cli.command {
-            Some(Commands::New(args)) => {
+            Some(Commands::Repo {
+                action: RepoAction::Add(args),
+            }) => {
+                assert_eq!(args.repo, vec!["app-c", "app-d"]);
                 assert_eq!(args.preset.as_deref(), Some("work"));
-                assert!(args.repo.is_empty());
             }
-            other => panic!("expected New, got {:?}", other),
+            other => panic!("expected Repo Add, got {:?}", other),
         }
     }
 
     #[test]
-    fn test_new_preset_and_repo_conflict() {
-        let result = try_parse(&["new", "my-session", "--preset", "work", "--repo", "app"]);
-        assert!(result.is_err());
+    fn test_repo_add_requires_repo() {
+        assert!(try_parse(&["repo", "add", "--workspace", "my-session"]).is_err());
     }
 
     #[test]
-    fn test_new_with_repo_flags() {
-        let cli = parse(&["new", "my-session", "--repo", "app-a", "--repo", "app-b"]);
+    fn test_repo_add_workspace_and_preset_conflict() {
+        assert!(try_parse(&[
+            "repo",
+            "add",
+            "app",
+            "--workspace",
+            "ws",
+            "--preset",
+            "work"
+        ])
+        .is_err());
+    }
+
+    #[test]
+    fn test_repo_remove_from_workspace() {
+        let cli = parse(&["repo", "remove", "app-a", "--workspace", "my-session"]);
         match cli.command {
-            Some(Commands::New(args)) => {
-                assert_eq!(args.name, "my-session");
-                assert_eq!(args.repo, vec!["app-a", "app-b"]);
+            Some(Commands::Repo {
+                action: RepoAction::Remove(args),
+            }) => {
+                assert_eq!(args.repo, vec!["app-a"]);
+                assert_eq!(args.workspace.as_deref(), Some("my-session"));
             }
-            other => panic!("expected New, got {:?}", other),
+            other => panic!("expected Repo Remove, got {:?}", other),
         }
     }
 
     #[test]
-    fn test_new_default_strategy() {
-        let cli = parse(&["new", "my-session", "--repo", "app"]);
-        match cli.command {
-            Some(Commands::New(args)) => {
-                assert_eq!(args.strategy, "worktree");
-            }
-            other => panic!("expected New, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn test_new_with_strategy_clone() {
-        let cli = parse(&["new", "my-session", "--repo", "app", "--strategy", "clone"]);
-        match cli.command {
-            Some(Commands::New(args)) => {
-                assert_eq!(args.strategy, "clone");
-            }
-            other => panic!("expected New, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn test_new_no_fetch_defaults_false() {
-        let cli = parse(&["new", "my-session", "--repo", "app"]);
-        match cli.command {
-            Some(Commands::New(args)) => {
-                assert!(!args.no_fetch);
-            }
-            other => panic!("expected New, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn test_new_with_no_fetch_flag() {
-        let cli = parse(&["new", "my-session", "--repo", "app", "--no-fetch"]);
-        match cli.command {
-            Some(Commands::New(args)) => {
-                assert!(args.no_fetch);
-            }
-            other => panic!("expected New, got {:?}", other),
-        }
-    }
-
-    // -- edit subcommand --
-
-    #[test]
-    fn test_edit_parses() {
-        let cli = parse(&["edit", "my-session"]);
-        match cli.command {
-            Some(Commands::Edit(args)) => {
-                assert_eq!(args.name, "my-session");
-                assert!(args.add.is_empty());
-                assert!(args.remove.is_empty());
-            }
-            other => panic!("expected Edit, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn test_edit_requires_name() {
-        let result = try_parse(&["edit"]);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_edit_with_add_and_remove_flags() {
-        let cli = parse(&[
-            "edit",
-            "my-session",
-            "--add",
-            "app-c",
-            "--add",
-            "app-d",
-            "--remove",
-            "app-a",
-        ]);
-        match cli.command {
-            Some(Commands::Edit(args)) => {
-                assert_eq!(args.name, "my-session");
-                assert_eq!(args.add, vec!["app-c", "app-d"]);
-                assert_eq!(args.remove, vec!["app-a"]);
-            }
-            other => panic!("expected Edit, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn test_edit_add_only() {
-        let cli = parse(&["edit", "my-session", "--add", "app-c"]);
-        match cli.command {
-            Some(Commands::Edit(args)) => {
-                assert_eq!(args.add, vec!["app-c"]);
-                assert!(args.remove.is_empty());
-            }
-            other => panic!("expected Edit, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn test_edit_remove_only() {
-        let cli = parse(&["edit", "my-session", "--remove", "app-a"]);
-        match cli.command {
-            Some(Commands::Edit(args)) => {
-                assert!(args.add.is_empty());
-                assert_eq!(args.remove, vec!["app-a"]);
-            }
-            other => panic!("expected Edit, got {:?}", other),
-        }
-    }
-
-    // -- remove subcommand --
-
-    #[test]
-    fn test_remove_parses() {
-        let cli = parse(&["remove", "my-session"]);
-        match cli.command {
-            Some(Commands::Remove(args)) => {
-                assert_eq!(args.name.as_deref(), Some("my-session"));
-                assert!(!args.all);
-            }
-            other => panic!("expected Remove, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn test_remove_alias_rm() {
-        let cli = parse(&["rm", "my-session"]);
-        match cli.command {
-            Some(Commands::Remove(args)) => {
-                assert_eq!(args.name.as_deref(), Some("my-session"));
-            }
-            other => panic!("expected Remove, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn test_remove_no_name_parses() {
-        let cli = parse(&["remove"]);
-        match cli.command {
-            Some(Commands::Remove(args)) => {
-                assert!(args.name.is_none());
-                assert!(!args.all);
-            }
-            other => panic!("expected Remove, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn test_remove_all_flag_parses() {
-        let cli = parse(&["remove", "--all"]);
-        match cli.command {
-            Some(Commands::Remove(args)) => {
-                assert!(args.name.is_none());
-                assert!(args.all);
-            }
-            other => panic!("expected Remove, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn test_remove_all_short_flag_parses() {
-        let cli = parse(&["rm", "-a"]);
-        match cli.command {
-            Some(Commands::Remove(args)) => {
-                assert!(args.all);
-            }
-            other => panic!("expected Remove, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn test_remove_all_conflicts_with_name() {
-        let result = try_parse(&["remove", "--all", "my-session"]);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_remove_rejects_unknown_flags() {
-        let result = try_parse(&["remove", "my-session", "-d"]);
-        assert!(result.is_err());
-    }
-
-    // -- cd subcommand --
-
-    #[test]
-    fn test_switch_subcommand_parses() {
-        let cli = parse(&["switch", "my-session"]);
+    fn test_repo_remove_alias_rm() {
+        let cli = parse(&["repo", "rm", "app-a", "--workspace", "my-session"]);
         assert!(matches!(
             cli.command,
-            Some(Commands::Switch { ref name }) if name == "my-session"
+            Some(Commands::Repo {
+                action: RepoAction::Remove(_)
+            })
         ));
     }
 
     #[test]
-    fn test_switch_alias_cd() {
-        let cli = parse(&["cd", "my-session"]);
+    fn test_repo_list_workspace() {
+        let cli = parse(&["repo", "list", "--workspace", "my-session"]);
+        match cli.command {
+            Some(Commands::Repo {
+                action: RepoAction::List(args),
+            }) => assert_eq!(args.workspace.as_deref(), Some("my-session")),
+            other => panic!("expected Repo List, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_repo_list_alias_ls() {
+        let cli = parse(&["repo", "ls", "--preset", "work"]);
+        match cli.command {
+            Some(Commands::Repo {
+                action: RepoAction::List(args),
+            }) => assert_eq!(args.preset.as_deref(), Some("work")),
+            other => panic!("expected Repo List, got {:?}", other),
+        }
+    }
+
+    // -- workspace remove subcommand --
+
+    fn ws_remove(cli: Cli) -> RemoveArgs {
+        match cli.command {
+            Some(Commands::Workspace {
+                action: WorkspaceAction::Remove(args),
+            }) => args,
+            other => panic!("expected Workspace Remove, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_remove_parses() {
+        let args = ws_remove(parse(&["workspace", "remove", "my-session"]));
+        assert_eq!(args.name.as_deref(), Some("my-session"));
+        assert!(!args.all);
+    }
+
+    #[test]
+    fn test_remove_alias_rm() {
+        let args = ws_remove(parse(&["workspace", "rm", "my-session"]));
+        assert_eq!(args.name.as_deref(), Some("my-session"));
+    }
+
+    #[test]
+    fn test_remove_no_name_parses() {
+        let args = ws_remove(parse(&["workspace", "remove"]));
+        assert!(args.name.is_none());
+        assert!(!args.all);
+    }
+
+    #[test]
+    fn test_remove_all_flag_parses() {
+        let args = ws_remove(parse(&["workspace", "remove", "--all"]));
+        assert!(args.name.is_none());
+        assert!(args.all);
+    }
+
+    #[test]
+    fn test_remove_all_short_flag_parses() {
+        let args = ws_remove(parse(&["workspace", "rm", "-a"]));
+        assert!(args.all);
+    }
+
+    #[test]
+    fn test_remove_all_conflicts_with_name() {
+        assert!(try_parse(&["workspace", "remove", "--all", "my-session"]).is_err());
+    }
+
+    #[test]
+    fn test_remove_rejects_unknown_flags() {
+        assert!(try_parse(&["workspace", "remove", "my-session", "-d"]).is_err());
+    }
+
+    // -- workspace switch subcommand --
+
+    #[test]
+    fn test_switch_subcommand_parses() {
+        let cli = parse(&["workspace", "switch", "my-session"]);
         assert!(matches!(
             cli.command,
-            Some(Commands::Switch { ref name }) if name == "my-session"
+            Some(Commands::Workspace {
+                action: WorkspaceAction::Switch { ref name }
+            }) if name == "my-session"
         ));
     }
 
     #[test]
     fn test_switch_alias_sw() {
-        let cli = parse(&["sw", "my-session"]);
+        let cli = parse(&["workspace", "sw", "my-session"]);
         assert!(matches!(
             cli.command,
-            Some(Commands::Switch { ref name }) if name == "my-session"
+            Some(Commands::Workspace {
+                action: WorkspaceAction::Switch { ref name }
+            }) if name == "my-session"
         ));
     }
 
     #[test]
     fn test_switch_requires_name() {
-        let result = try_parse(&["switch"]);
-        assert!(result.is_err());
+        assert!(try_parse(&["workspace", "switch"]).is_err());
     }
 
     // -- upgrade subcommand --
@@ -1354,121 +1452,104 @@ mod tests {
         assert!(result.is_err());
     }
 
-    // -- list subcommand --
+    // -- workspace list subcommand --
+
+    fn ws_list(cli: Cli) -> ListArgs {
+        match cli.command {
+            Some(Commands::Workspace {
+                action: WorkspaceAction::List(args),
+            }) => args,
+            other => panic!("expected Workspace List, got {:?}", other),
+        }
+    }
 
     #[test]
     fn test_list_no_flags() {
-        let cli = parse(&["list"]);
-        match cli.command {
-            Some(Commands::List(args)) => {
-                assert!(!args.quiet);
-            }
-            other => panic!("expected List, got {:?}", other),
-        }
+        assert!(!ws_list(parse(&["workspace", "list"])).quiet);
     }
 
     #[test]
     fn test_list_quiet_flag() {
-        let cli = parse(&["list", "-q"]);
-        match cli.command {
-            Some(Commands::List(args)) => {
-                assert!(args.quiet);
-            }
-            other => panic!("expected List, got {:?}", other),
-        }
+        assert!(ws_list(parse(&["workspace", "list", "-q"])).quiet);
     }
 
     #[test]
     fn test_list_alias_ls() {
-        let cli = parse(&["ls"]);
-        match cli.command {
-            Some(Commands::List(args)) => {
-                assert!(!args.quiet);
-            }
-            other => panic!("expected List, got {:?}", other),
-        }
+        assert!(!ws_list(parse(&["workspace", "ls"])).quiet);
     }
 
     #[test]
     fn test_list_rejects_positional_args() {
-        let result = try_parse(&["list", "my-session"]);
-        assert!(result.is_err());
+        assert!(try_parse(&["workspace", "list", "my-session"]).is_err());
     }
 
-    // -- repo subcommand --
+    // -- source subcommand (registry) --
 
     #[test]
-    fn test_repo_add_no_path() {
-        let cli = parse(&["repo", "add"]);
+    fn test_source_add_requires_path() {
+        assert!(try_parse(&["source", "add"]).is_err());
+    }
+
+    #[test]
+    fn test_source_add_with_path() {
+        let cli = parse(&["source", "add", "/tmp/my-repo"]);
         match cli.command {
-            Some(Commands::Repo {
-                action: RepoAction::Add { src },
-            }) => {
-                assert!(src.is_none());
-            }
-            other => panic!("expected Repo Add, got {:?}", other),
+            Some(Commands::Source {
+                action: SourceAction::Add { src },
+            }) => assert_eq!(src, "/tmp/my-repo"),
+            other => panic!("expected Source Add, got {:?}", other),
         }
     }
 
     #[test]
-    fn test_repo_add_with_path() {
-        let cli = parse(&["repo", "add", "/tmp/my-repo"]);
+    fn test_source_add_with_url() {
+        let cli = parse(&["source", "add", "git@github.com:user/app.git"]);
         match cli.command {
-            Some(Commands::Repo {
-                action: RepoAction::Add { src },
-            }) => {
-                assert_eq!(src.as_deref(), Some("/tmp/my-repo"));
-            }
-            other => panic!("expected Repo Add, got {:?}", other),
+            Some(Commands::Source {
+                action: SourceAction::Add { src },
+            }) => assert_eq!(src, "git@github.com:user/app.git"),
+            other => panic!("expected Source Add, got {:?}", other),
         }
     }
 
     #[test]
-    fn test_repo_add_with_url() {
-        let cli = parse(&["repo", "add", "git@github.com:user/app.git"]);
+    fn test_source_remove() {
+        let cli = parse(&["source", "remove", "my-app"]);
         match cli.command {
-            Some(Commands::Repo {
-                action: RepoAction::Add { src },
-            }) => {
-                assert_eq!(src.as_deref(), Some("git@github.com:user/app.git"));
-            }
-            other => panic!("expected Repo Add, got {:?}", other),
+            Some(Commands::Source {
+                action: SourceAction::Remove { name },
+            }) => assert_eq!(name, "my-app"),
+            other => panic!("expected Source Remove, got {:?}", other),
         }
     }
 
     #[test]
-    fn test_repo_remove() {
-        let cli = parse(&["repo", "remove", "my-app"]);
+    fn test_source_remove_alias_rm() {
+        let cli = parse(&["source", "rm", "my-app"]);
         match cli.command {
-            Some(Commands::Repo {
-                action: RepoAction::Remove { name },
-            }) => {
-                assert_eq!(name, "my-app");
-            }
-            other => panic!("expected Repo Remove, got {:?}", other),
+            Some(Commands::Source {
+                action: SourceAction::Remove { name },
+            }) => assert_eq!(name, "my-app"),
+            other => panic!("expected Source Remove, got {:?}", other),
         }
     }
 
     #[test]
-    fn test_repo_remove_alias_rm() {
-        let cli = parse(&["repo", "rm", "my-app"]);
-        match cli.command {
-            Some(Commands::Repo {
-                action: RepoAction::Remove { name },
-            }) => {
-                assert_eq!(name, "my-app");
-            }
-            other => panic!("expected Repo Remove, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn test_repo_list() {
-        let cli = parse(&["repo", "list"]);
+    fn test_source_list() {
         assert!(matches!(
-            cli.command,
-            Some(Commands::Repo {
-                action: RepoAction::List
+            parse(&["source", "list"]).command,
+            Some(Commands::Source {
+                action: SourceAction::List
+            })
+        ));
+    }
+
+    #[test]
+    fn test_source_list_alias_ls() {
+        assert!(matches!(
+            parse(&["source", "ls"]).command,
+            Some(Commands::Source {
+                action: SourceAction::List
             })
         ));
     }
@@ -1489,17 +1570,6 @@ mod tests {
             }
             other => panic!("expected Preset Add, got {:?}", other),
         }
-    }
-
-    #[test]
-    fn test_preset_edit_parses() {
-        let cli = parse(&["preset", "edit", "work"]);
-        assert!(matches!(
-            cli.command,
-            Some(Commands::Preset {
-                action: PresetAction::Edit { name }
-            }) if name == "work"
-        ));
     }
 
     #[test]
@@ -1556,7 +1626,14 @@ mod tests {
 
     #[test]
     fn test_new_update_flag_rejected() {
-        let result = try_parse(&["new", "my-session", "--repo", "app", "--update"]);
+        let result = try_parse(&[
+            "workspace",
+            "add",
+            "my-session",
+            "--repo",
+            "app",
+            "--update",
+        ]);
         assert!(result.is_err());
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -192,7 +192,7 @@ fn clear_viewport(
 pub fn create_session() -> Result<TuiAction> {
     let all_repos = repo::list()?;
     if all_repos.is_empty() {
-        anyhow::bail!("No repos registered. Run `box repo add <url>` first.");
+        anyhow::bail!("No sources registered. Run `box source add <url>` first.");
     }
 
     let mut presets = preset::list()?;
@@ -521,7 +521,7 @@ fn select_repos(
     initial_selected: Vec<bool>,
 ) -> Result<TuiAction> {
     if all_repos.is_empty() {
-        anyhow::bail!("No repos registered. Run `box repo add <url>` first.");
+        anyhow::bail!("No sources registered. Run `box source add <url>` first.");
     }
 
     let repo_count = all_repos.len();
@@ -631,21 +631,6 @@ fn select_repos(
             }
         }
     }
-}
-
-/// TUI for editing session repos: shows checkbox list of all registered repos
-/// with the session's current repos pre-selected. Returns updated repo list.
-pub fn edit_session(current_repos: &[String]) -> Result<TuiAction> {
-    let all_repos = repo::list()?;
-    let selected = all_repos
-        .iter()
-        .map(|r| current_repos.contains(&r.name))
-        .collect();
-    select_repos(
-        all_repos,
-        "Edit repos (Space=toggle, Enter=confirm):",
-        selected,
-    )
 }
 
 /// TUI for selecting repos for a preset: shows checkbox list of all registered repos.


### PR DESCRIPTION
## Summary

- Restructure the whole command surface into consistent **noun-verb groups** and remove all implicit current-directory resolution.
  - `box workspace add|list|remove|switch` (alias `ws`; `ls`/`rm`/`sw` within the group) — replaces top-level `new`/`list`/`remove`/`switch`.
  - `box repo add|remove|list --workspace|--preset <name>` — replaces `box edit` **and** `preset edit`; manages repos in a workspace or preset, target is required (mutually exclusive).
  - `box source add|remove|list` — the old `box repo` registry; `box source add` now requires an explicit `<src>` (use `.` for cwd).
  - `box rebase <branch> --workspace <name> --repo <name>` — no more cwd resolution.
- Drop `box list --project` (cwd-based filter) and the now-dead `git::find_root`, `tui::edit_session`, `resolve_project_dir`.
- Embed an **LLM-friendly mental model + conventions** in `box --help` (`long_about`): the source → workspace → repo/preset tiers, typical flow, and "every command targets an explicit object" rules.
- Rewrite zsh/bash completions and the README for the new surface.
- Version bump `0.2.1 → 0.3.0` (breaking).

The only non-explicit entry points left are interactive TUIs (`box` with no args, `box workspace remove` with no name, `box preset add` with no `--repo`); there is **no** implicit cwd/env target resolution anywhere.

## Code Review

Reviewed the full diff in `hew`. Three findings were raised for curation and the human left them as-is (accepted, no changes requested):

1. **Preset last-repo removal** — `box repo remove <last> --preset X` errors because `preset::add` rejects an empty list. Left as-is (deliberate; not emptying presets implicitly).
2. **`repo list` vs `source list` output** — `repo list` prints one name per line (script-friendly); `source list` prints an aligned table. Intentional difference.
3. **Clean break, no deprecation shims** — old verbs are gone; `box repo add <path>` changed meaning but now safely errors without a target. Deliberate for a pre-1.0 personal tool.

### Review Checklist
- [x] Formatter — `cargo fmt --all` clean
- [x] Linter / static checks — `cargo clippy --all-targets -- -D warnings` clean (warnings: none; removed 3 dead-code items + a dangling doc comment)
- [x] Tests — `cargo test` 134 passed
- [x] Full diff reviewed against: correctness, error handling, performance, security, conventions, tests, dead code

## Test plan

- `cargo fmt --all --check && cargo clippy --all-targets -- -D warnings && cargo test`
- Manual smoke (with a temp `BOX_ROOT`):
  - `box source add <path>` registers a source; `box source add` (no arg) now errors with `<SRC>` required.
  - `box workspace add feat --repo app --strategy clone --no-fetch` then `box workspace list` / `box workspace remove feat`.
  - `box repo add app --workspace feat` / `box repo list --workspace feat`; `box repo add app` (no target) errors with "Specify a target with --workspace/--preset".
  - `box --help` shows the mental-model `long_about`; `box repo add --help` shows `<REPO>... + --workspace/--preset`.