### PR TITLE
completion: only offer canonical subcommands, not aliases

### DIFF
--- a/src/completions/box.bash
+++ b/src/completions/box.bash
@@ -37,7 +37,7 @@ _box() {
     local cur prev words cword
     _init_completion || return
 
-    local subcommands="workspace ws repo source preset rebase upgrade config"
+    local subcommands="workspace repo source preset rebase upgrade config"
 
     if [[ $cword -eq 1 ]]; then
         COMPREPLY=($(compgen -W "$subcommands" -- "$cur"))
@@ -50,7 +50,7 @@ _box() {
     case "$sub" in
         workspace|ws)
             if [[ $cword -eq 2 ]]; then
-                COMPREPLY=($(compgen -W "add list ls remove rm switch sw" -- "$cur"))
+                COMPREPLY=($(compgen -W "add list remove switch" -- "$cur"))
                 return
             fi
             case "${words[2]}" in
@@ -84,7 +84,7 @@ _box() {
             ;;
         repo)
             if [[ $cword -eq 2 ]]; then
-                COMPREPLY=($(compgen -W "add remove rm list ls" -- "$cur"))
+                COMPREPLY=($(compgen -W "add remove list" -- "$cur"))
                 return
             fi
             case "$prev" in
@@ -108,7 +108,7 @@ _box() {
             ;;
         source)
             if [[ $cword -eq 2 ]]; then
-                COMPREPLY=($(compgen -W "add remove rm list ls" -- "$cur"))
+                COMPREPLY=($(compgen -W "add remove list" -- "$cur"))
             elif [[ $cword -eq 3 ]]; then
                 case "${words[2]}" in
                     remove|rm)
@@ -122,7 +122,7 @@ _box() {
             ;;
         preset)
             if [[ $cword -eq 2 ]]; then
-                COMPREPLY=($(compgen -W "add remove rm list ls" -- "$cur"))
+                COMPREPLY=($(compgen -W "add remove list" -- "$cur"))
                 return
             fi
             if [[ "$prev" == "--repo" ]]; then

--- a/src/completions/box.zsh
+++ b/src/completions/box.zsh
@@ -65,7 +65,6 @@ _box() {
             local -a subcmds
             subcmds=(
                 'workspace:Manage workspaces (create, list, switch, remove)'
-                'ws:Manage workspaces (alias of workspace)'
                 'repo:Manage repos within a workspace or preset'
                 'source:Manage registered sources (upstream git repos)'
                 'preset:Manage presets'
@@ -83,11 +82,8 @@ _box() {
                         ws_subcmds=(
                             'add:Create a new workspace'
                             'list:List workspaces'
-                            'ls:List workspaces'
                             'remove:Remove a workspace'
-                            'rm:Remove a workspace'
                             'switch:Switch into a workspace'
-                            'sw:Switch into a workspace'
                         )
                         _describe 'workspace subcommand' ws_subcmds
                     else
@@ -124,9 +120,7 @@ _box() {
                         repo_subcmds=(
                             'add:Add repo(s) to a workspace or preset'
                             'remove:Remove repo(s) from a workspace or preset'
-                            'rm:Remove repo(s) from a workspace or preset'
                             'list:List repos in a workspace or preset'
-                            'ls:List repos in a workspace or preset'
                         )
                         _describe 'repo subcommand' repo_subcmds
                     else
@@ -151,9 +145,7 @@ _box() {
                         source_subcmds=(
                             'add:Register a git repo as a source'
                             'remove:Unregister a source'
-                            'rm:Unregister a source'
                             'list:List registered sources'
-                            'ls:List registered sources'
                         )
                         _describe 'source subcommand' source_subcmds
                     elif (( CURRENT == 3 )); then
@@ -173,9 +165,7 @@ _box() {
                         preset_subcmds=(
                             'add:Create or update a preset'
                             'remove:Remove a preset'
-                            'rm:Remove a preset'
                             'list:List presets'
-                            'ls:List presets'
                         )
                         _describe 'preset subcommand' preset_subcmds
                     elif (( CURRENT == 3 )); then


### PR DESCRIPTION
## Summary
- Shell completion no longer offers alias shorthands (`ws`, `ls`, `rm`, `sw`) as separate candidates, so `box w[tab]` completes straight to `workspace` instead of showing the redundant `workspace`/`ws` pair.
- Applied consistently across all groups (top-level, `workspace`, `repo`, `source`, `preset`) in both zsh and bash completion scripts.
- Aliases still work when typed manually — the `case workspace|ws)`, `list|ls)`, etc. dispatch branches are untouched.

## Code Review
Reviewed the full diff of both completion scripts via hew. Only the candidate lists fed to `_describe` (zsh) / `compgen -W` (bash) changed; the alias-handling `case` branches are preserved, so no functional CLI behavior is lost. Human review returned an empty action log (no changes requested).

### Review Checklist
- [x] Formatter — passed (no Rust changed; `cargo fmt` clean)
- [x] Linter / static checks — `cargo clippy --all-targets -- -D warnings` passed (warnings: none)
- [x] Tests — `cargo test` passed (134 passed)
- [x] Shell syntax — `bash -n` / `zsh -n` both pass
- [x] Full diff reviewed against: correctness, error handling, performance, security, conventions, tests, dead code

## Test plan
- `eval "$(box config zsh)"` then type `box w<TAB>` → completes to `workspace` (no `ws` shown).
- `box workspace <TAB>` → shows `add list remove switch` (no `ls`/`rm`/`sw`).
- Verify aliases still function: `box ws ls`, `box repo rm ...` behave as before.