### PR TITLE
preset: split add into create-only add + replace-only update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "box-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "box-cli"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Sandboxed git workspaces for development"
 license = "MIT"

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
         box = pkgs.rustPlatform.buildRustPackage {
           pname = "box";
-          version = "0.3.0";
+          version = "0.4.0";
 
           src = ./.;
 

--- a/src/completions/box.bash
+++ b/src/completions/box.bash
@@ -122,7 +122,7 @@ _box() {
             ;;
         preset)
             if [[ $cword -eq 2 ]]; then
-                COMPREPLY=($(compgen -W "add remove list" -- "$cur"))
+                COMPREPLY=($(compgen -W "add update remove list" -- "$cur"))
                 return
             fi
             if [[ "$prev" == "--repo" ]]; then
@@ -131,6 +131,13 @@ _box() {
             case "${words[2]}" in
                 remove|rm)
                     [[ $cword -eq 3 ]] && COMPREPLY=($(compgen -W "$(__box_presets_list)" -- "$cur"))
+                    ;;
+                update)
+                    if [[ $cword -eq 3 ]]; then
+                        COMPREPLY=($(compgen -W "$(__box_presets_list)" -- "$cur"))
+                    elif [[ "$cur" == -* ]]; then
+                        COMPREPLY=($(compgen -W "--repo" -- "$cur"))
+                    fi
                     ;;
                 add)
                     [[ "$cur" == -* ]] && COMPREPLY=($(compgen -W "--repo" -- "$cur"))

--- a/src/completions/box.zsh
+++ b/src/completions/box.zsh
@@ -163,18 +163,19 @@ _box() {
                     if (( CURRENT == 2 )); then
                         local -a preset_subcmds
                         preset_subcmds=(
-                            'add:Create or update a preset'
+                            'add:Create a new preset'
+                            'update:Replace an existing preset'"'"'s repos'
                             'remove:Remove a preset'
                             'list:List presets'
                         )
                         _describe 'preset subcommand' preset_subcmds
                     elif (( CURRENT == 3 )); then
                         case $words[2] in
-                            remove|rm)
+                            remove|rm|update)
                                 __box_presets
                                 ;;
                         esac
-                    elif [[ $words[2] == "add" ]]; then
+                    elif [[ $words[2] == "add" || $words[2] == "update" ]]; then
                         _arguments \
                             '*--repo=[Select specific source]:source:__box_repos'
                     fi

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ CONVENTIONS (important for scripting/agents):\n\
   - `box rebase` requires --workspace <name> and --repo <name>.\n\
   - Subcommand aliases: workspace=ws, and within each group list=ls, remove=rm, switch=sw.\n\
   - `box` with no arguments launches an interactive TUI to create a workspace.",
-    after_help = "Examples:\n  box                                          # interactive workspace manager\n  box workspace add my-feature --repo app-a    # create a workspace (alias: ws)\n  box workspace add my-feature --preset work   # create from a preset\n  box workspace list                           # list workspaces (alias: ls)\n  box workspace switch my-feature              # switch into a workspace (alias: sw)\n  box workspace remove my-feature              # remove a workspace (alias: rm)\n  box repo add app-c --workspace my-feature    # add a repo to a workspace\n  box repo remove app-a --workspace my-feature # remove a repo from a workspace\n  box repo list --workspace my-feature         # list repos in a workspace\n  box repo add app-c --preset work             # add a repo to a preset\n  box source add git@github.com:user/app.git   # register a source from a URL\n  box source add .                             # register current dir as a source\n  box source list                              # list registered sources\n  box source remove my-app                     # unregister a source\n  box preset add work --repo app-a --repo app-b # define a preset\n  box preset list                              # list presets\n  box rebase main --workspace my-feature --repo app-a # fetch & rebase a repo\n  box upgrade                                  # self-update"
+    after_help = "Examples:\n  box                                          # interactive workspace manager\n  box workspace add my-feature --repo app-a    # create a workspace (alias: ws)\n  box workspace add my-feature --preset work   # create from a preset\n  box workspace list                           # list workspaces (alias: ls)\n  box workspace switch my-feature              # switch into a workspace (alias: sw)\n  box workspace remove my-feature              # remove a workspace (alias: rm)\n  box repo add app-c --workspace my-feature    # add a repo to a workspace\n  box repo remove app-a --workspace my-feature # remove a repo from a workspace\n  box repo list --workspace my-feature         # list repos in a workspace\n  box repo add app-c --preset work             # add a repo to a preset\n  box source add git@github.com:user/app.git   # register a source from a URL\n  box source add .                             # register current dir as a source\n  box source list                              # list registered sources\n  box source remove my-app                     # unregister a source\n  box preset add work --repo app-a --repo app-b # define a new preset\n  box preset update work --repo app-a --repo app-c # replace a preset's repos\n  box preset list                              # list presets\n  box rebase main --workspace my-feature --repo app-a # fetch & rebase a repo\n  box upgrade                                  # self-update"
 )]
 struct Cli {
     /// Show detailed output
@@ -133,8 +133,16 @@ enum SourceAction {
 
 #[derive(Subcommand, Debug)]
 enum PresetAction {
-    /// Create or update a preset
+    /// Create a new preset (fails if it already exists)
     Add {
+        /// Preset name
+        name: String,
+        /// Repos to include (can be repeated; opens interactive selector if omitted)
+        #[arg(long)]
+        repo: Vec<String>,
+    },
+    /// Replace an existing preset's repos (fails if it doesn't exist)
+    Update {
         /// Preset name
         name: String,
         /// Repos to include (can be repeated; opens interactive selector if omitted)
@@ -274,6 +282,7 @@ fn main() {
         },
         Some(Commands::Preset { action }) => match action {
             PresetAction::Add { name, repo } => cmd_preset_add(&name, &repo),
+            PresetAction::Update { name, repo } => cmd_preset_update(&name, &repo),
             PresetAction::Remove { name } => cmd_preset_remove(&name),
             PresetAction::List => cmd_preset_list(),
         },
@@ -590,7 +599,7 @@ fn cmd_repo_modify(
                 .map(|r| r.as_str())
                 .collect();
 
-            preset::add(&name, &new_repos)?;
+            preset::update(&name, &new_repos)?;
 
             if !added.is_empty() {
                 eprintln!("\x1b[2madded:\x1b[0m {}", added.join(", "));
@@ -922,14 +931,18 @@ fn cmd_source_list() -> Result<i32> {
 
 fn cmd_preset_add(name: &str, repos: &[String]) -> Result<i32> {
     if repos.is_empty() {
-        // Interactive repo selection — pre-select existing preset repos if updating.
+        // Creating a new preset: bail early (before opening the interactive
+        // selector) if one already exists under this name.
         // validate_name is called by load(), so path traversal is rejected.
-        let current = match preset::load(name) {
-            Ok(repos) => repos,
-            Err(e) if e.to_string().contains("No preset named") => Vec::new(),
+        match preset::load(name) {
+            Ok(_) => bail!(
+                "Preset '{}' already exists. Use `box preset update` to replace it.",
+                name
+            ),
+            Err(e) if e.to_string().contains("No preset named") => {}
             Err(e) => return Err(e),
-        };
-        match tui::select_preset_repos(&current)? {
+        }
+        match tui::select_preset_repos(&[])? {
             tui::TuiAction::Edit { repos } => {
                 preset::add(name, &repos)?;
             }
@@ -939,6 +952,26 @@ fn cmd_preset_add(name: &str, repos: &[String]) -> Result<i32> {
         }
     } else {
         preset::add(name, repos)?;
+    }
+    Ok(0)
+}
+
+fn cmd_preset_update(name: &str, repos: &[String]) -> Result<i32> {
+    if repos.is_empty() {
+        // Updating an existing preset: pre-select its current repos in the
+        // interactive selector. load() also gives a clear error if the
+        // preset doesn't exist, before we bother opening the TUI.
+        let current = preset::load(name)?;
+        match tui::select_preset_repos(&current)? {
+            tui::TuiAction::Edit { repos } => {
+                preset::update(name, &repos)?;
+            }
+            _ => {
+                return Ok(0);
+            }
+        }
+    } else {
+        preset::update(name, repos)?;
     }
     Ok(0)
 }
@@ -1569,6 +1602,22 @@ mod tests {
                 assert_eq!(repo, vec!["app-a", "app-b"]);
             }
             other => panic!("expected Preset Add, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_preset_update_parses() {
+        let cli = parse(&[
+            "preset", "update", "work", "--repo", "app-a", "--repo", "app-c",
+        ]);
+        match cli.command {
+            Some(Commands::Preset {
+                action: PresetAction::Update { name, repo },
+            }) => {
+                assert_eq!(name, "work");
+                assert_eq!(repo, vec!["app-a", "app-c"]);
+            }
+            other => panic!("expected Preset Update, got {:?}", other),
         }
     }
 

--- a/src/preset.rs
+++ b/src/preset.rs
@@ -56,8 +56,32 @@ pub fn load(name: &str) -> Result<Vec<String>> {
     Ok(repos)
 }
 
+/// Create a new preset. Fails if a preset with this name already exists —
+/// use `update` to replace an existing one's repo list.
 pub fn add(name: &str, repos: &[String]) -> Result<()> {
     validate_name(name)?;
+    let path = presets_dir()?.join(name);
+    if path.is_file() {
+        bail!(
+            "Preset '{}' already exists. Use `box preset update` to replace it.",
+            name
+        );
+    }
+    write_preset(name, repos, "saved")
+}
+
+/// Replace an existing preset's repo list. Fails if no preset with this name
+/// exists — use `add` to create a new one.
+pub fn update(name: &str, repos: &[String]) -> Result<()> {
+    validate_name(name)?;
+    let path = presets_dir()?.join(name);
+    if !path.is_file() {
+        bail!("No preset named '{}' found.", name);
+    }
+    write_preset(name, repos, "updated")
+}
+
+fn write_preset(name: &str, repos: &[String], verb: &str) -> Result<()> {
     if repos.is_empty() {
         bail!("A preset must contain at least one repo.");
     }
@@ -83,10 +107,8 @@ pub fn add(name: &str, repos: &[String]) -> Result<()> {
     fs::create_dir_all(&dir)?;
 
     let path = dir.join(name);
-    let exists = path.is_file();
     fs::write(&path, unique.join("\n") + "\n")?;
 
-    let verb = if exists { "updated" } else { "saved" };
     eprintln!(
         "Preset '\x1b[1m{}\x1b[0m' {} ({}).",
         name,
@@ -239,7 +261,7 @@ mod tests {
     }
 
     #[test]
-    fn test_add_overwrites() {
+    fn test_add_rejects_existing() {
         with_temp_home(|home| {
             let repo_a = make_git_repo(home, "app-a");
             let repo_b = make_git_repo(home, "app-b");
@@ -247,10 +269,36 @@ mod tests {
             repo::add(repo_b.to_str().unwrap()).unwrap();
 
             add("work", &["app-a".to_string()]).unwrap();
-            add("work", &["app-b".to_string()]).unwrap();
+            let err = add("work", &["app-b".to_string()]).unwrap_err();
+            assert!(err.to_string().contains("already exists"));
+
+            // Original repo list is untouched.
+            let repos = load("work").unwrap();
+            assert_eq!(repos, vec!["app-a"]);
+        });
+    }
+
+    #[test]
+    fn test_update_replaces_existing() {
+        with_temp_home(|home| {
+            let repo_a = make_git_repo(home, "app-a");
+            let repo_b = make_git_repo(home, "app-b");
+            repo::add(repo_a.to_str().unwrap()).unwrap();
+            repo::add(repo_b.to_str().unwrap()).unwrap();
+
+            add("work", &["app-a".to_string()]).unwrap();
+            update("work", &["app-b".to_string()]).unwrap();
 
             let repos = load("work").unwrap();
             assert_eq!(repos, vec!["app-b"]);
+        });
+    }
+
+    #[test]
+    fn test_update_rejects_missing() {
+        with_temp_home(|_| {
+            let err = update("nonexistent", &["app-a".to_string()]).unwrap_err();
+            assert!(err.to_string().contains("No preset named"));
         });
     }
 


### PR DESCRIPTION
## Summary
- `box preset add` previously upserted silently (created *or* overwrote), unlike `workspace add` / `source add` which both error if the target already exists — this made it easy to accidentally clobber an existing preset.
- Split into two commands: `box preset add <name>` now fails if the preset already exists; new `box preset update <name>` replaces an existing preset's repos and fails if it doesn't exist.
- `box repo add/remove --preset <name>` (incremental repo edits) now calls the new `preset::update` internally.
- zsh/bash completions updated for the new `update` subcommand.

## Code Review
Reviewed via `hew` against the full diff. Two informational notes were raised (duplicated error message string between `preset.rs`/`main.rs`, and the intentional breaking-change note below) — human reviewed and made no change requests (empty action log). No issues to fix.

### Review Checklist
- [x] Formatter — passed (`cargo fmt`, no diff)
- [x] Linter / static checks — passed (`cargo clippy --all-targets -- -D warnings`, no warnings)
- [x] Tests — passed (`cargo test`, 137 passed)
- [x] Full diff reviewed against: correctness, error handling, performance, security, conventions, tests, dead code

### Notes for Reviewer
- **Breaking behavior change**: `box preset add <existing-name> --repo ...` now errors instead of silently overwriting the preset. Use `box preset update` for that case. Any scripts/aliases relying on the old upsert behavior will need updating.

## Test plan
- `cargo test` — 137 passed
- Manual: `box preset add work --repo app-a` then `box preset add work --repo app-b` → second call errors ("already exists"); `box preset update work --repo app-b` → replaces repos successfully.