### PR TITLE
release: automate Homebrew formula updates

### DIFF
--- a/.github/scripts/update-homebrew-formula.py
+++ b/.github/scripts/update-homebrew-formula.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Update the box Homebrew formula from release artifacts."""
+
+import argparse
+import re
+from pathlib import Path
+
+ASSETS = (
+    "box-aarch64-darwin",
+    "box-x86_64-darwin",
+    "box-aarch64-linux",
+    "box-x86_64-linux",
+)
+
+
+def checksum_for(artifacts: Path, asset: str) -> str:
+    matches = list(artifacts.rglob(f"{asset}.sha256"))
+    if len(matches) != 1:
+        raise ValueError(f"expected one checksum for {asset}, found {len(matches)}")
+
+    checksum = matches[0].read_text().split()[0]
+    if not re.fullmatch(r"[0-9a-f]{64}", checksum):
+        raise ValueError(f"invalid SHA-256 checksum for {asset}: {checksum}")
+    return checksum
+
+
+def update_formula(formula: Path, version: str, artifacts: Path) -> None:
+    if not re.fullmatch(r"\d+\.\d+\.\d+", version):
+        raise ValueError(f"invalid stable version: {version}")
+
+    content = formula.read_text()
+    content, count = re.subn(
+        r'(?m)^  version "[^"]+"$', f'  version "{version}"', content
+    )
+    if count != 1:
+        raise ValueError(f"expected one version declaration, found {count}")
+
+    for asset in ASSETS:
+        checksum = checksum_for(artifacts, asset)
+        pattern = (
+            rf'(?m)(url "[^"]+/{re.escape(asset)}"\n'
+            rf'\s+sha256 ")[0-9a-f]{{64}}("$)'
+        )
+        content, count = re.subn(pattern, rf"\g<1>{checksum}\2", content)
+        if count != 1:
+            raise ValueError(f"expected one formula entry for {asset}, found {count}")
+
+    formula.write_text(content)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--artifacts", required=True, type=Path)
+    parser.add_argument("--formula", required=True, type=Path)
+    args = parser.parse_args()
+
+    update_formula(args.formula, args.version, args.artifacts)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,3 +168,40 @@ jobs:
           prerelease: ${{ contains(needs.check-version.outputs.version, '-') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  homebrew:
+    name: Update Homebrew formula
+    needs: [check-version, release]
+    if: needs.check-version.outputs.should_release == 'true' && !contains(needs.check-version.outputs.version, '-')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout box
+        uses: actions/checkout@v4
+
+      - name: Download release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Checkout Homebrew tap
+        uses: actions/checkout@v4
+        with:
+          repository: yusukeshib/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+
+      - name: Update formula
+        run: |
+          python3 .github/scripts/update-homebrew-formula.py \
+            --version '${{ needs.check-version.outputs.version }}' \
+            --artifacts artifacts \
+            --formula homebrew-tap/Formula/box.rb
+
+      - name: Push formula update
+        working-directory: homebrew-tap
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/box.rb
+          git commit -m "box: update to v${{ needs.check-version.outputs.version }}"
+          git push


### PR DESCRIPTION
## Summary
- update the Homebrew tap after each stable release
- derive all platform checksums from release artifacts
- skip prereleases and validate formula inputs

## Validation
- generated the v0.5.0 formula from published checksum artifacts
- verified the current macOS release asset against its published checksum
- `git diff --check`
- `python3 -m py_compile .github/scripts/update-homebrew-formula.py`